### PR TITLE
Set default group for secret file based on OS

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -57,7 +57,10 @@
 
       group = lib.mkOption {
         type = lib.types.str;
-        default = "users";
+        default =
+          if pkgs.stdenv.isDarwin
+          then "staff"
+          else config.home.username;
         description = "Group that owns the secret file";
       };
 


### PR DESCRIPTION
The default group "users" does not exist for the home-manager module on macOS. This PR set the default group ownership for secret files as platform-specific.