### PR TITLE
fix: use hostPlatform.system to avoid deprecation warning

### DIFF
--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -25,7 +25,7 @@
 
   # Create a new pkgs instance with our overlay
   pkgsWithOverlay = import pkgs.path {
-    inherit (pkgs) system;
+    system = pkgs.stdenv.hostPlatform.system;
     overlays = [
       (final: prev: {
         opnix = import ./package.nix {pkgs = final;};

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -22,7 +22,7 @@
 
   # Create a new pkgs instance with our overlay
   pkgsWithOverlay = import pkgs.path {
-    inherit (pkgs) system;
+    system = pkgs.stdenv.hostPlatform.system;
     overlays = [
       (final: prev: {
         opnix = import ./package.nix {pkgs = final;};

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -22,7 +22,7 @@
 
   # Create a new pkgs instance with our overlay
   pkgsWithOverlay = import pkgs.path {
-    inherit (pkgs) system;
+    system = pkgs.stdenv.hostPlatform.system;
     overlays = [
       (final: prev: {
         opnix = import ./package.nix {pkgs = final;};


### PR DESCRIPTION
Fixes evaluation warning: `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`