### PR TITLE
fix: avoid opnix service restart deadlocks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
 
 watch_file flake.nix

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -229,6 +229,8 @@ When using advanced service configuration (NixOS only), each service supports:
 - **Default**: `["opnix-secrets.service"]`
 - **Description**: Additional systemd dependencies for this service
 
+Prefer ordering managed services with `After=opnix-secrets.service` and `Wants=opnix-secrets.service`. Avoid `Requires=opnix-secrets.service` unless the service must fail hard when OpNix fails; hard requirements can deadlock if OpNix triggers a restart while the managed service is ordered after `opnix-secrets.service`.
+
 ### Path Template Configuration
 
 #### `pathTemplate`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -363,13 +363,27 @@ ERROR: Found dependency loop involving opnix-secrets.service
    ```
 
 3. **Use proper service ordering:**
+    ```nix
+    # Instead, make services depend on OpNix:
+    services.onepassword-secrets.systemdIntegration = {
+      enable = true;
+      services = ["postgresql"];
+    };
+    ```
+
+4. **Avoid hard requirements from managed services:**
    ```nix
-   # Instead, make services depend on OpNix:
-   services.onepassword-secrets.systemdIntegration = {
-     enable = true;
-     services = ["postgresql"];
+   # Prefer this:
+   systemd.services.postgresql = {
+     after = [ "opnix-secrets.service" ];
+     wants = [ "opnix-secrets.service" ];
    };
+
+   # Avoid this unless PostgreSQL must fail hard when OpNix fails:
+   systemd.services.postgresql.requires = [ "opnix-secrets.service" ];
    ```
+
+   `Requires=opnix-secrets.service` can deadlock during OpNix-triggered restarts: the managed service waits for `opnix-secrets.service` to finish while OpNix is waiting for the managed service action to complete.
 
 ## Network and Connectivity Issues
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
     in {
       packages.default = buildOpnix;
       inherit checks;
+      devShells.default = import ./nix/devshell.nix {inherit pkgs buildOpnix;};
       formatter = pkgs.alejandra;
     })
     // {

--- a/internal/systemd/integration.go
+++ b/internal/systemd/integration.go
@@ -374,18 +374,9 @@ func (m *Manager) ProcessSecretChanges(secrets []config.Secret, secretPaths map[
 	return nil
 }
 
-func (m *Manager) collectRecoveryActions(configuredActions, changedActions []ServiceAction) ([]ServiceAction, error) {
-	changedServices := make(map[string]struct{}, len(changedActions))
-	for _, action := range changedActions {
-		changedServices[action.Name] = struct{}{}
-	}
-
+func (m *Manager) collectRecoveryActions(configuredActions, _ []ServiceAction) ([]ServiceAction, error) {
 	var recoveryActions []ServiceAction
 	for _, action := range configuredActions {
-		if _, exists := changedServices[action.Name]; exists {
-			continue
-		}
-
 		recoverService, err := m.shouldRecoverService(action.Name)
 		if err != nil {
 			if m.config.ErrorHandling.ContinueOnError {
@@ -421,18 +412,15 @@ func (m *Manager) processServiceActions(actions []ServiceAction) error {
 	// Group actions by service to avoid duplicate operations
 	serviceActions := make(map[string]ServiceAction)
 	for _, action := range actions {
-		// If we already have an action for this service, prefer restart over reload
+		// Start wins over restart/reload because try-restart is a no-op for inactive units.
 		if existing, exists := serviceActions[action.Name]; exists {
 			if existing.Start {
-				if action.Restart || action.Signal != "" {
-					serviceActions[action.Name] = action
-				}
 				continue
 			}
 
-			if action.Restart && !existing.Restart {
+			if action.Start {
 				serviceActions[action.Name] = action
-			} else if action.Start && !existing.Restart && existing.Signal == "" {
+			} else if action.Restart && !existing.Restart {
 				serviceActions[action.Name] = action
 			}
 		} else {

--- a/internal/systemd/integration.go
+++ b/internal/systemd/integration.go
@@ -471,7 +471,7 @@ func (m *Manager) executeServiceAction(action ServiceAction) error {
 
 	if action.Start {
 		cmd = m.systemctl
-		args = []string{"start", action.Name}
+		args = []string{"--no-block", "start", action.Name}
 		fmt.Printf("INFO: Starting service %s\n", action.Name)
 	} else if action.Signal != "" {
 		// Send custom signal
@@ -481,12 +481,12 @@ func (m *Manager) executeServiceAction(action ServiceAction) error {
 	} else if action.Restart {
 		// Restart service
 		cmd = m.systemctl
-		args = []string{"restart", action.Name}
+		args = []string{"--no-block", "try-restart", action.Name}
 		fmt.Printf("INFO: Restarting service %s\n", action.Name)
 	} else {
 		// Reload service
 		cmd = m.systemctl
-		args = []string{"reload", action.Name}
+		args = []string{"--no-block", "reload", action.Name}
 		fmt.Printf("INFO: Reloading service %s\n", action.Name)
 	}
 

--- a/internal/systemd/integration_test.go
+++ b/internal/systemd/integration_test.go
@@ -464,8 +464,78 @@ func TestProcessSecretChangesRecoversDependencyBlockedServices(t *testing.T) {
 		t.Fatalf("Failed to read fake systemctl log: %v", err)
 	}
 
-	if string(logContent) != "start test-service\n" {
+	if string(logContent) != "--no-block start test-service\n" {
 		t.Fatalf("expected dependency-blocked service to be started, got %q", string(logContent))
+	}
+}
+
+func TestProcessSecretChangesRestartsChangedServicesWithoutBlocking(t *testing.T) {
+	tempDir := t.TempDir()
+	hashFile := filepath.Join(tempDir, "test-hashes.json")
+	logFile := filepath.Join(tempDir, "systemctl.log")
+	fakeSystemctl := writeFakeSystemctl(t, tempDir)
+
+	t.Setenv("FAKE_SYSTEMCTL_DIR", tempDir)
+	t.Setenv("FAKE_SYSTEMCTL_LOG", logFile)
+
+	secretPath := filepath.Join(tempDir, "test-secret.txt")
+	if err := os.WriteFile(secretPath, []byte("old-secret-content"), 0600); err != nil {
+		t.Fatalf("Failed to create test secret: %v", err)
+	}
+
+	store, err := NewHashStore(hashFile)
+	if err != nil {
+		t.Fatalf("Failed to create hash store: %v", err)
+	}
+	if _, err := store.hasChanged(secretPath); err != nil {
+		t.Fatalf("Failed to seed hash store: %v", err)
+	}
+	if err := store.save(); err != nil {
+		t.Fatalf("Failed to save seeded hash store: %v", err)
+	}
+
+	if err := os.WriteFile(secretPath, []byte("new-secret-content"), 0600); err != nil {
+		t.Fatalf("Failed to update test secret: %v", err)
+	}
+
+	manager := &Manager{
+		config: config.SystemdIntegration{
+			Enable:          true,
+			RestartOnChange: true,
+			ChangeDetection: config.ChangeDetection{
+				Enable:   true,
+				HashFile: hashFile,
+			},
+			ErrorHandling: config.ErrorHandling{
+				ContinueOnError: true,
+				MaxRetries:      1,
+			},
+		},
+		hashStore: store,
+		systemctl: fakeSystemctl,
+	}
+
+	secrets := []config.Secret{{
+		Path:      "test/secret",
+		Reference: "op://vault/item/field",
+		Services:  []interface{}{"test-service"},
+	}}
+
+	secretPaths := map[string]string{
+		"secret[0]:test/secret": secretPath,
+	}
+
+	if err := manager.ProcessSecretChanges(secrets, secretPaths); err != nil {
+		t.Fatalf("ProcessSecretChanges failed: %v", err)
+	}
+
+	logContent, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("Failed to read fake systemctl log: %v", err)
+	}
+
+	if string(logContent) != "--no-block try-restart test-service\n" {
+		t.Fatalf("expected changed service to be restarted without blocking, got %q", string(logContent))
 	}
 }
 
@@ -550,7 +620,10 @@ case "$1" in
   show)
     cat "$FAKE_SYSTEMCTL_DIR/$2.status"
     ;;
-  start|restart|reload)
+  --no-block)
+    printf '%s %s %s\n' "$1" "$2" "$3" >> "$FAKE_SYSTEMCTL_LOG"
+    ;;
+  start|restart|reload|try-restart)
     printf '%s %s\n' "$1" "$2" >> "$FAKE_SYSTEMCTL_LOG"
     ;;
   cat)

--- a/internal/systemd/integration_test.go
+++ b/internal/systemd/integration_test.go
@@ -539,6 +539,80 @@ func TestProcessSecretChangesRestartsChangedServicesWithoutBlocking(t *testing.T
 	}
 }
 
+func TestProcessSecretChangesStartsChangedDependencyBlockedServices(t *testing.T) {
+	tempDir := t.TempDir()
+	hashFile := filepath.Join(tempDir, "test-hashes.json")
+	logFile := filepath.Join(tempDir, "systemctl.log")
+	fakeSystemctl := writeFakeSystemctl(t, tempDir)
+
+	t.Setenv("FAKE_SYSTEMCTL_DIR", tempDir)
+	t.Setenv("FAKE_SYSTEMCTL_LOG", logFile)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "test-service.status"), []byte("ActiveState=inactive\nSubState=dead\nResult=dependency\n"), 0600); err != nil {
+		t.Fatalf("Failed to write fake service status: %v", err)
+	}
+
+	secretPath := filepath.Join(tempDir, "test-secret.txt")
+	if err := os.WriteFile(secretPath, []byte("old-secret-content"), 0600); err != nil {
+		t.Fatalf("Failed to create test secret: %v", err)
+	}
+
+	store, err := NewHashStore(hashFile)
+	if err != nil {
+		t.Fatalf("Failed to create hash store: %v", err)
+	}
+	if _, err := store.hasChanged(secretPath); err != nil {
+		t.Fatalf("Failed to seed hash store: %v", err)
+	}
+	if err := store.save(); err != nil {
+		t.Fatalf("Failed to save seeded hash store: %v", err)
+	}
+
+	if err := os.WriteFile(secretPath, []byte("new-secret-content"), 0600); err != nil {
+		t.Fatalf("Failed to update test secret: %v", err)
+	}
+
+	manager := &Manager{
+		config: config.SystemdIntegration{
+			Enable:          true,
+			RestartOnChange: true,
+			ChangeDetection: config.ChangeDetection{
+				Enable:   true,
+				HashFile: hashFile,
+			},
+			ErrorHandling: config.ErrorHandling{
+				ContinueOnError: true,
+				MaxRetries:      1,
+			},
+		},
+		hashStore: store,
+		systemctl: fakeSystemctl,
+	}
+
+	secrets := []config.Secret{{
+		Path:      "test/secret",
+		Reference: "op://vault/item/field",
+		Services:  []interface{}{"test-service"},
+	}}
+
+	secretPaths := map[string]string{
+		"secret[0]:test/secret": secretPath,
+	}
+
+	if err := manager.ProcessSecretChanges(secrets, secretPaths); err != nil {
+		t.Fatalf("ProcessSecretChanges failed: %v", err)
+	}
+
+	logContent, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("Failed to read fake systemctl log: %v", err)
+	}
+
+	if string(logContent) != "--no-block start test-service\n" {
+		t.Fatalf("expected changed dependency-blocked service to be started, got %q", string(logContent))
+	}
+}
+
 func TestProcessSecretChangesSkipsHealthyServicesWhenUnchanged(t *testing.T) {
 	tempDir := t.TempDir()
 	hashFile := filepath.Join(tempDir, "test-hashes.json")

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -36,6 +36,12 @@ in
     ];
 
     shellHook = ''
+      case " ''${GOFLAGS:-} " in
+        *" -mod=vendor "*)
+          export GOFLAGS="''${GOFLAGS//-mod=vendor/}"
+          ;;
+      esac
+
       ${lib.optionalString (tokenPath != null) ''
         if [ -z "''${OPNIX_ENV_TOKEN_FILE:-}" ]; then
           export OPNIX_ENV_TOKEN_FILE=${lib.escapeShellArg tokenPath}
@@ -44,26 +50,30 @@ in
 
       if [ -n "''${OPNIX_ENV_DISABLE:-}" ]; then
         echo "INFO: OPNIX_ENV_DISABLE set, skipping opnix env exports" >&2
-      elif [ ${
+      ${
         if configArg == null
-        then "0"
-        else "1"
-      } -eq 0 ]; then
-        echo "WARNING: no opnix environment configuration provided" >&2
-      else
-        token_args=()
-        if [ -z "''${OPNIX_ENV_TOKEN_FILE:-}" ]; then
-          export OPNIX_ENV_TOKEN_FILE="''${HOME}/.config/opnix/token"
-        fi
-        if [ -n "''${OPNIX_ENV_TOKEN_FILE:-}" ]; then
-          token_args=(-token-file "''${OPNIX_ENV_TOKEN_FILE}")
-        fi
+        then ''
+          else
+            echo "WARNING: no opnix environment configuration provided" >&2
+          fi
+        ''
+        else ''
+          else
+            token_args=()
+            if [ -z "''${OPNIX_ENV_TOKEN_FILE:-}" ]; then
+              export OPNIX_ENV_TOKEN_FILE="''${HOME}/.config/opnix/token"
+            fi
+            if [ -n "''${OPNIX_ENV_TOKEN_FILE:-}" ]; then
+              token_args=(-token-file "''${OPNIX_ENV_TOKEN_FILE}")
+            fi
 
-        if output="$(${buildOpnix}/bin/opnix env ${configArg.flag} ${configArg.value} -format shell "''${token_args[@]}")"; then
-          eval "$output"
-        else
-          echo "WARNING: failed to resolve opnix environment variables" >&2
-        fi
-      fi
+            if output="$(${buildOpnix}/bin/opnix env ${configArg.flag} ${configArg.value} -format shell "''${token_args[@]}")"; then
+              eval "$output"
+            else
+              echo "WARNING: failed to resolve opnix environment variables" >&2
+            fi
+          fi
+        ''
+      }
     '';
   }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -393,14 +393,17 @@ in {
             after = ["network-online.target" "nss-lookup.target"];
             wants = ["network-online.target" "nss-lookup.target"];
 
+            unitConfig = {
+              StartLimitIntervalSec = "1h";
+              StartLimitBurst = 2;
+            };
+
             serviceConfig = {
               Type = "oneshot";
               RemainAfterExit = true;
               Restart = "on-failure";
               RestartSec = "15min";
-              RestartPreventExitStatus = 65;
-              StartLimitIntervalSec = "1h";
-              StartLimitBurst = 2;
+              RestartPreventExitStatus = "65 75";
               User = "root";
               Group = opnixGroup;
             };


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Summary
- Avoid systemd activation deadlocks by using non-blocking service actions and `try-restart` for changed services.
- Emit OpNix service start-limit settings in `[Unit]` and prevent retries for missing-reference and rate-limit exits.
- Add the default dev shell output and refresh nix-direnv pinning so `direnv` and `nix develop -c go test ./... -count=1` work without vendor-mode pollution.

## Testing
- `nix develop -c go test ./... -count=1`
- `direnv export bash`
- `nix flake check`
- `git diff --check`