### PR TITLE
feat: install opnix CLI via NixOS module systemPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Set up your token:
 ```bash
 sudo nixos-rebuild switch --flake .
 sudo opnix token set
+sudo systemctl restart opnix-secrets.service
 ```
 
 > **Note:** On NixOS, `opnix` is automatically added to `environment.systemPackages` once

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ sudo opnix token set
 sudo nixos-rebuild switch --flake .
 ```
 
-> **Note:** `opnix` is automatically on `$PATH` once `services.onepassword-secrets.enable = true`
-> and you rebuild — no separate CLI install or overlay needed. Remove any existing manual
-> `systemPackages`/overlay entry for `opnix`.
+> **Note:** On NixOS, `opnix` is automatically added to `environment.systemPackages` once
+> `services.onepassword-secrets.enable = true` and you rebuild — no separate CLI install or
+> overlay needed. If you previously added `opnix` manually on NixOS, that entry is now
+> redundant and can be removed. (On nix-darwin and Home Manager, CLI installation is
+> unchanged.)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ sudo opnix token set
 sudo nixos-rebuild switch --flake .
 ```
 
+> **Note:** `opnix` is automatically on `$PATH` once `services.onepassword-secrets.enable = true`
+> and you rebuild — no separate CLI install or overlay needed. Remove any existing manual
+> `systemPackages`/overlay entry for `opnix`.
+
 ## Documentation
 
 📚 **[Complete Documentation](./docs/README.md)**

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ programs.onepassword-secrets = {
 Set up your token:
 
 ```bash
-sudo opnix token set
 sudo nixos-rebuild switch --flake .
+sudo opnix token set
 ```
 
 > **Note:** On NixOS, `opnix` is automatically added to `environment.systemPackages` once

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -193,6 +193,12 @@ darwin-rebuild switch --flake .
 home-manager switch --flake .
 ```
 
+> **Note:** On NixOS, enabling `services.onepassword-secrets.enable = true` now adds
+> `opnix` to `environment.systemPackages` automatically, so the rebuild above is the
+> only install step required. If you previously added `opnix` via a manual overlay
+> or your own `environment.systemPackages` entry, that entry is now redundant and can
+> be removed.
+
 **Set the token** using the OpNix CLI:
 
 ```bash

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -386,6 +386,11 @@ in {
             })
             cfg.users);
 
+          # Make the CLI available on PATH without requiring a manual overlay.
+          # lib.lowPrio avoids a buildEnv collision if the user already added
+          # opnix to systemPackages manually — their copy silently wins.
+          environment.systemPackages = [(lib.lowPrio pkgsWithOverlay.opnix)];
+
           # Create systemd service instead of activation script
           systemd.services.opnix-secrets = {
             description = "OpNix Secret Management";


### PR DESCRIPTION
## Summary

The NixOS module (`nix/module.nix`) now adds `opnix` to `environment.systemPackages`
whenever `services.onepassword-secrets` is enabled — parity with the Home Manager
module's existing `home.packages = [pkgsWithOverlay.opnix]` behavior. Today the
Home Manager module puts the CLI on `$PATH` automatically, but the NixOS module
does not, so `opnix token set` (etc.) isn't available out of the box on a system
that only uses the NixOS service.

## What changed

```nix
environment.systemPackages = [(lib.lowPrio pkgsWithOverlay.opnix)];
```

added inside the existing `lib.mkIf cfg.enable` block, reusing the same
`pkgsWithOverlay.opnix` binding the systemd service already resolves from
(no second, potentially-divergent package evaluation).

## Collision safety (buildEnv)

The added package is wrapped in `lib.lowPrio` (nixpkgs `meta.priority = 10` vs.
the default `5`). `pkgs.buildEnv` resolves same-path collisions by keeping the
**lower**-priority entry, so if a user already has their own `opnix` entry in
`environment.systemPackages` (e.g. from a manual overlay), their copy silently
wins the collision and the rebuild does not fail. There is no toggle for this
behavior — it's unconditional whenever the service module is enabled, matching
the Home Manager module's existing behavior.

## Migration note for existing users

If you previously added `opnix` to your own `environment.systemPackages` (or
via a manual overlay) to work around the CLI not being on `$PATH`, that entry
is now redundant — the module handles it for you. You can remove it; nothing
else changes.

## Scope

This PR is scoped to the NixOS CLI-install fix only. It does not touch the
Home Manager or nix-darwin modules, the Go CLI, or any other feature area.

## Testing

- `nix flake check --impure` (module eval, go tests, go-lint, alejandra fmt) passes.
- Verified via nixpkgs `lib/meta.nix` semantics that `lowPrio` = `setPrio 10` and
  `buildEnv` keeps the lower-priority store path on a name collision.
