### PR TITLE
fix(secrets): reconcile declared file modes

### DIFF
--- a/internal/secrets/processor.go
+++ b/internal/secrets/processor.go
@@ -171,6 +171,16 @@ func (p *Processor) processSecret(secret config.Secret, secretName, value string
 		}
 	}
 
+	// WriteFile preserves permissions for existing files, so reconcile the declared mode explicitly.
+	if err := os.Chmod(outputPath, os.FileMode(fileMode)); err != nil {
+		return "", errors.FileOperationError(
+			fmt.Sprintf("Setting permissions for %s", secretName),
+			outputPath,
+			fmt.Sprintf("Failed to change permissions to %s", mode),
+			err,
+		)
+	}
+
 	// Create symlinks if specified
 	if err := p.createSymlinks(outputPath, secret.Symlinks, secretName); err != nil {
 		return "", err

--- a/internal/secrets/processor_test.go
+++ b/internal/secrets/processor_test.go
@@ -216,6 +216,83 @@ func TestProcessorWithOwnership(t *testing.T) {
 	}
 }
 
+func TestProcessorReconcilesExistingFileMode(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingContent string
+		secretContent   string
+		existingMode    os.FileMode
+		declaredMode    string
+		expectedMode    os.FileMode
+	}{
+		{
+			name:            "content and mode changed",
+			existingContent: "old-secret-value",
+			secretContent:   "new-secret-value",
+			existingMode:    0600,
+			declaredMode:    "0400",
+			expectedMode:    0400,
+		},
+		{
+			name:            "mode changed with identical content",
+			existingContent: "same-secret-value",
+			secretContent:   "same-secret-value",
+			existingMode:    0600,
+			declaredMode:    "0400",
+			expectedMode:    0400,
+		},
+		{
+			name:            "default mode restored",
+			existingContent: "same-secret-value",
+			secretContent:   "same-secret-value",
+			existingMode:    0644,
+			expectedMode:    0600,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			outputPath := filepath.Join(tmpDir, "secret")
+			if err := os.WriteFile(outputPath, []byte(tt.existingContent), tt.existingMode); err != nil {
+				t.Fatalf("Failed to create existing secret: %v", err)
+			}
+			if err := os.Chmod(outputPath, tt.existingMode); err != nil {
+				t.Fatalf("Failed to set existing secret mode: %v", err)
+			}
+
+			processor := NewProcessor(&mockClient{secrets: map[string]string{
+				"op://vault/item/field": tt.secretContent,
+			}}, tmpDir)
+			cfg := &config.Config{Secrets: []config.Secret{{
+				Path:      "secret",
+				Reference: "op://vault/item/field",
+				Mode:      tt.declaredMode,
+			}}}
+
+			if _, err := processor.Process(cfg); err != nil {
+				t.Fatalf("Failed to process existing secret: %v", err)
+			}
+
+			content, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatalf("Failed to read processed secret: %v", err)
+			}
+			if string(content) != tt.secretContent {
+				t.Errorf("Expected secret content %q, got %q", tt.secretContent, string(content))
+			}
+
+			info, err := os.Stat(outputPath)
+			if err != nil {
+				t.Fatalf("Failed to stat processed secret: %v", err)
+			}
+			if info.Mode().Perm() != tt.expectedMode {
+				t.Errorf("Expected permissions %04o, got %04o", tt.expectedMode, info.Mode().Perm())
+			}
+		})
+	}
+}
+
 func TestProcessorModeValidation(t *testing.T) {
 	// Create mock client
 	mock := &mockClient{


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes

## Summary
- Reapply each secret's declared mode after writing and ownership reconciliation so existing files cannot retain stale permissions.
- Cover content rewrites, mode-only drift with identical content, and restoration of the default `0600` mode.
- Source paths: `internal/secrets/processor.go`, `internal/secrets/processor_test.go`

## Scope Check
- Matches issue because: Ryan explicitly replaced MMI-920's upstream-report request with implementing the confirmed mode reconciliation fix in OpNix.
- Changed file groups: the secret processor applies the final mode; processor tests prove existing-file and mode-only reconciliation.
- Out of scope / deferred: systemd metadata-based change detection, path-type hardening, and special Unix mode-bit behavior remain unchanged.

## Validation
- `nix develop -c go test ./internal/secrets -count=1` passed.
- `nix develop -c go test ./... -count=1` passed.
- `nix develop -c go vet ./...` passed.
- `nix flake check` passed, including the repository-configured Go lint derivation.
- Direct `nix develop -c golangci-lint run ./...` reports 14 pre-existing `errcheck` findings outside this diff; the repository's configured lint check excludes the intended test findings and passes.

## Follow-ups
- None.