### PR TITLE
fix(secrets): guide rollback-safe reference migrations

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -266,7 +266,6 @@ services.onepassword-secrets.systemdIntegration = {
   services = ["caddy" "postgresql"];
   restartOnChange = true;
   changeDetection.enable = true;
-  errorHandling.rollbackOnFailure = true;
 };
 ```
 
@@ -311,7 +310,8 @@ services.onepassword-secrets.systemdIntegration = {
 ##### `errorHandling.rollbackOnFailure`
 - **Type**: `bool`
 - **Default**: `false`
-- **Description**: Restore previous secrets on deployment failure
+- **Description**: Reserved for future secret-file rollback handling; currently has no runtime effect
+- **Notes**: This option does not roll back NixOS generations or preserve 1Password references used by older generations. Keep retired fields available through the rollback window instead.
 
 ##### `errorHandling.continueOnError`
 - **Type**: `bool`
@@ -592,9 +592,9 @@ services.onepassword-secrets = {
 };
 ```
 
-### Change Detection and Rollback
+### Change Detection and Rollback Limits
 
-Enable advanced error handling:
+Configure content-based change detection:
 
 ```nix
 services.onepassword-secrets.systemdIntegration = {
@@ -603,13 +603,13 @@ services.onepassword-secrets.systemdIntegration = {
     enable = true;
     hashFile = "/var/lib/opnix/secret-hashes";
   };
-  errorHandling = {
-    rollbackOnFailure = true;
-    continueOnError = false;
-    maxRetries = 5;
-  };
 };
 ```
+
+`rollbackOnFailure` is currently reserved and does not restore secret files or
+roll back a NixOS generation. See
+[Secret Reference Migrations and Rollback Safety](./migration-guide.md#secret-reference-migrations-and-rollback-safety)
+before changing or deleting a 1Password field used by a deployed generation.
 
 ### Custom Token Locations
 

--- a/docs/examples/caddy-ssl.md
+++ b/docs/examples/caddy-ssl.md
@@ -216,7 +216,6 @@ Fields:
         hashFile = "/var/lib/opnix/ssl-hashes";
       };
       errorHandling = {
-        rollbackOnFailure = true;
         continueOnError = false;
       };
     };

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -239,6 +239,13 @@ ls -la ~/.ssh/
 ls -la ~/.config/myapp/
 ```
 
+When changing a 1Password reference, keep the old field available until the
+new generation has been verified and older generations that use the old field
+are no longer expected to be used for rollback. NixOS generations retain the
+reference, not the secret value, so an older generation cannot resolve a field
+that has already been deleted. See
+[Secret Reference Migrations and Rollback Safety](./migration-guide.md#secret-reference-migrations-and-rollback-safety).
+
 ## Platform-Specific Notes
 
 ### NixOS

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -356,6 +356,48 @@ sudo systemctl restart opnix-secrets.service
 sudo systemctl status postgresql.service caddy.service
 ```
 
+## Secret Reference Migrations and Rollback Safety
+
+NixOS generations retain OpNix configuration, including each `op://` reference,
+but secret values remain in 1Password and are resolved when
+`opnix-secrets.service` runs. Deleting or renaming a referenced field can
+therefore break an older generation even though the generation itself remains
+available for rollback.
+
+Use an overlap window whenever a reference changes:
+
+1. Create and populate the replacement field in 1Password.
+2. Update the Nix configuration to use the replacement reference.
+3. Build and test the new generation before switching to it.
+4. Verify `opnix-secrets.service` and its recent journal entries after the switch.
+5. Keep the old field available while any retained generation may still be used
+   as a rollback target.
+6. Remove the old field only after that rollback window has closed.
+
+For example, keep `op://Example/Service/old-field` available while deploying a
+generation that uses `op://Example/Service/new-field`. Do not copy secret values
+into the Nix store to make generations self-contained.
+
+```bash
+# Build without activating the generation
+nix build .#nixosConfigurations.HOST.config.system.build.toplevel
+
+# Test, then activate the generation
+sudo nixos-rebuild test --flake .#HOST
+sudo nixos-rebuild switch --flake .#HOST
+
+# Verify without printing secret contents
+sudo systemctl status opnix-secrets.service
+sudo journalctl -u opnix-secrets.service --since "15 minutes ago"
+sudo find /var/lib/opnix/secrets -type f -exec ls -la {} \;
+```
+
+If an older generation fails with exit code `65`, restore its retired field in
+1Password, restart `opnix-secrets.service`, and retain the field until that
+generation is no longer a rollback target. OpNix resolves all references before
+writing files, so a reference-resolution failure leaves existing secret files
+unchanged.
+
 ## Platform-Specific Migration
 
 ### NixOS Migration
@@ -533,7 +575,6 @@ services.onepassword-secrets = {
     enable = true;
     changeDetection.enable = true;
     errorHandling = {
-      rollbackOnFailure = true;
       continueOnError = false;
       maxRetries = 5;
     };

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -512,6 +512,44 @@ op item list --vault "Vault"
    # Check service account permissions in 1Password console
    ```
 
+### Issue: Rollback Generation References a Retired Field
+
+**Symptoms:**
+
+- `opnix-secrets.service` fails after activating an older NixOS generation.
+- The journal reports a missing reference and systemd records exit code `65`.
+- The same reference worked when that generation was originally deployed.
+
+Each generation stores its OpNix configuration and `op://` references, but not
+the corresponding secret values. If a field was later renamed or deleted in
+1Password, the older generation cannot resolve it.
+
+**Recovery:**
+
+1. Review the service log to identify the missing reference:
+   ```bash
+   sudo journalctl -u opnix-secrets.service -n 50
+   ```
+   The full `op://` reference is logged. Treat its vault, item, and field names
+   as sensitive metadata and redact them before sharing logs.
+2. Restore the retired field in 1Password at its previous vault, item, and field
+   path. Do not place the secret value in the Nix configuration or Nix store.
+3. Retry secret materialization:
+   ```bash
+   sudo systemctl restart opnix-secrets.service
+   sudo systemctl status opnix-secrets.service
+   ```
+4. Keep the restored field until the affected generation is no longer retained
+   as a rollback target.
+
+OpNix resolves every configured reference before updating secret files. A
+missing-reference failure therefore preserves the existing materialized files,
+but services should not be restarted until the intended generation's references
+resolve successfully.
+
+See [Secret Reference Migrations and Rollback Safety](./migration-guide.md#secret-reference-migrations-and-rollback-safety)
+for the preventive deployment procedure.
+
 ### Issue: Configuration Validation Errors
 
 **Symptoms:**

--- a/internal/secrets/processor.go
+++ b/internal/secrets/processor.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	stderrors "errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -72,15 +73,27 @@ func (p *Processor) Process(cfg *config.Config) (*ProcessResult, error) {
 	references := uniqueReferences(cfg.Secrets)
 	resolvedSecrets, err := p.client.ResolveSecrets(references)
 	if err != nil {
+		suggestions := []string{
+			"Check the failed 1Password references listed above",
+			"Create any missing vaults, items, or fields before restarting opnix-secrets.service",
+			"If rate-limited, wait for the 1Password reset window before retrying",
+		}
+		var resolutionErr *errors.ProviderResolutionError
+		if stderrors.As(err, &resolutionErr) {
+			for _, failure := range resolutionErr.Failures {
+				if failure.Kind == errors.ProviderErrorMissingReference {
+					suggestions = append(suggestions,
+						"If this service belongs to an older NixOS generation, restore any retired 1Password references until its rollback window closes",
+					)
+					break
+				}
+			}
+		}
 		return nil, errors.WrapWithSuggestions(
 			err,
 			"Resolving 1Password references",
 			"secret processing",
-			[]string{
-				"Check the failed 1Password references listed above",
-				"Create any missing vaults, items, or fields before restarting opnix-secrets.service",
-				"If rate-limited, wait for the 1Password reset window before retrying",
-			},
+			suggestions,
 		)
 	}
 

--- a/internal/secrets/processor_test.go
+++ b/internal/secrets/processor_test.go
@@ -5,15 +5,18 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/brizzbuzz/opnix/internal/config"
+	"github.com/brizzbuzz/opnix/internal/errors"
 )
 
 // Mock client for testing
 type mockClient struct {
 	secrets      map[string]string
 	resolveCalls map[string]int
+	resolveErr   error
 }
 
 func (m *mockClient) ResolveSecret(reference string) (string, error) {
@@ -27,6 +30,10 @@ func (m *mockClient) ResolveSecret(reference string) (string, error) {
 }
 
 func (m *mockClient) ResolveSecrets(references []string) (map[string]string, error) {
+	if m.resolveErr != nil {
+		return nil, m.resolveErr
+	}
+
 	resolved := make(map[string]string, len(references))
 	for _, reference := range references {
 		value, err := m.ResolveSecret(reference)
@@ -36,6 +43,49 @@ func (m *mockClient) ResolveSecrets(references []string) (map[string]string, err
 		resolved[reference] = value
 	}
 	return resolved, nil
+}
+
+func TestProcessorMissingReferencePreservesExistingSecrets(t *testing.T) {
+	const reference = "op://Example/Service/old-field"
+	providerErr := &errors.ProviderResolutionError{Failures: []*errors.ProviderError{{
+		Kind:      errors.ProviderErrorMissingReference,
+		Reference: reference,
+		Issue:     "field_not_found",
+	}}}
+	tmpDir := t.TempDir()
+	existingPath := filepath.Join(tmpDir, "database/password")
+	if err := os.MkdirAll(filepath.Dir(existingPath), 0755); err != nil {
+		t.Fatalf("Failed to create existing secret directory: %v", err)
+	}
+	if err := os.WriteFile(existingPath, []byte("existing-secret"), 0600); err != nil {
+		t.Fatalf("Failed to create existing secret: %v", err)
+	}
+
+	processor := NewProcessor(&mockClient{resolveErr: providerErr}, tmpDir)
+	result, err := processor.Process(&config.Config{Secrets: []config.Secret{{
+		Path:      "database/password",
+		Reference: reference,
+	}}})
+	if err == nil {
+		t.Fatal("Expected missing reference error")
+	}
+	if result != nil {
+		t.Fatalf("Expected no process result, got %#v", result)
+	}
+	if got := errors.ExitCode(err); got != errors.ExitCodeMissingReference {
+		t.Fatalf("Expected exit code %d, got %d", errors.ExitCodeMissingReference, got)
+	}
+	if !strings.Contains(err.Error(), "older NixOS generation") {
+		t.Fatalf("Expected rollback recovery suggestion, got:\n%s", err)
+	}
+
+	content, readErr := os.ReadFile(existingPath)
+	if readErr != nil {
+		t.Fatalf("Failed to read existing secret: %v", readErr)
+	}
+	if string(content) != "existing-secret" {
+		t.Fatalf("Expected existing secret to remain unchanged, got %q", content)
+	}
 }
 
 func TestProcessor(t *testing.T) {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -266,7 +266,11 @@ in {
                 rollbackOnFailure = lib.mkOption {
                   type = lib.types.bool;
                   default = false;
-                  description = "Rollback secrets to previous versions if service restart fails";
+                  description = ''
+                    Reserved for future secret-file rollback handling. This option does not
+                    roll back NixOS generations or preserve 1Password references used by
+                    older generations.
+                  '';
                 };
 
                 continueOnError = lib.mkOption {


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Linear
- Issue: https://linear.app/brizzbuzz/issue/MMI-924/make-opnix-reference-migrations-rollback-safe
- Source report: https://github.com/brizzbuzz/opnix/issues/47

## Summary
- Add targeted recovery guidance when a classified missing 1Password reference may come from an older NixOS generation.
- Document overlap-window deployment and recovery procedures, and correct the currently inert `rollbackOnFailure` contract.
- Source paths: `internal/secrets/processor.go`, `internal/secrets/processor_test.go`, `nix/module.nix`, and operator documentation under `docs/`.

## Scope Check
- Matches issue because: missing-reference failures now preserve exit code `65`, explain old-generation recovery, and are tested to leave existing materialized secret content unchanged.
- Changed file groups: secret processor and regression test for diagnostics/atomic resolution; Nix option description and examples for accurate semantics; migration, getting-started, troubleshooting, and configuration guides for operator procedure.
- Out of scope / deferred: automatic NixOS generation rollback, historical-generation scanning, preflight commands, secret-file transactions, and provider/retry/systemd behavior changes.

## Validation
- `nix develop -c go test ./internal/secrets -count=1` passed.
- `nix develop -c go test ./... -count=1` passed.
- `nix flake check` passed, including Go tests, configured lint, Nix formatting, and module evaluation.
- `git diff --check` passed.
- Independent pre-PR review found two documentation issues; both were fixed and validation was rerun successfully.

## Follow-ups
- None.