### PR TITLE
docs(systemd): explain rate-limit restart policy

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -231,6 +231,11 @@ When using advanced service configuration (NixOS only), each service supports:
 
 Prefer ordering managed services with `After=opnix-secrets.service` and `Wants=opnix-secrets.service`. Avoid `Requires=opnix-secrets.service` unless the service must fail hard when OpNix fails; hard requirements can deadlock if OpNix triggers a restart while the managed service is ordered after `opnix-secrets.service`.
 
+`opnix-secrets.service` does not automatically restart after exit status `65`
+(missing, invalid, or ambiguous references) or `75` (1Password rate limiting).
+These conditions require configuration repair or waiting for the provider reset
+window rather than repeated systemd starts.
+
 ### Path Template Configuration
 
 #### `pathTemplate`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -468,6 +468,29 @@ ERROR: request timeout after 30 seconds
    };
    ```
 
+### Issue: 1Password Rate Limit Exceeded
+
+**Symptoms:**
+
+- OpNix reports that the 1Password rate limit was exceeded.
+- `opnix-secrets.service` exits with status `75`.
+- systemd does not automatically restart the service.
+
+Exit status `75` is deliberately included in `RestartPreventExitStatus`. Retrying
+immediately would consume more provider capacity and can exhaust the service's
+systemd start limit without resolving the failure.
+
+Wait for the 1Password rate limit to clear, then retry once:
+
+```bash
+sudo systemctl restart opnix-secrets.service
+sudo systemctl status opnix-secrets.service
+```
+
+If the service remains rate-limited, wait for the next reset window rather than
+looping manual restarts. Existing secret files remain available because OpNix
+resolves all references before updating them.
+
 ## Configuration Issues
 
 ### Issue: Invalid 1Password Reference

--- a/internal/onepass/client_test.go
+++ b/internal/onepass/client_test.go
@@ -205,3 +205,24 @@ func TestResolveSecretDoesNotRetryMissingReference(t *testing.T) {
 		t.Fatalf("expected exit code %d, got %d", opnixerrors.ExitCodeMissingReference, code)
 	}
 }
+
+func TestResolveSecretDoesNotRetryRateLimit(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		secrets: fakeSecretsAPI{resolveAll: func(_ context.Context, _ []string) (onepassword.ResolveAllResponse, error) {
+			attempts++
+			return onepassword.ResolveAllResponse{}, &onepassword.RateLimitExceededError{}
+		}},
+	}
+
+	_, err := client.ResolveSecret("op://vault/item/field")
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected rate-limited reference to be attempted once, got %d attempts", attempts)
+	}
+	if code := opnixerrors.ExitCode(err); code != opnixerrors.ExitCodeRateLimited {
+		t.Fatalf("expected exit code %d, got %d", opnixerrors.ExitCodeRateLimited, code)
+	}
+}


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Linear
- Issue: https://linear.app/brizzbuzz/issue/MMI-925/document-and-test-opnix-rate-limit-restart-policy

## Summary
- Document exit status `75`, why systemd deliberately prevents automatic rate-limit retries, and the safe manual retry procedure.
- Add provider-path regression coverage proving a top-level 1Password rate-limit response is attempted once and maps to exit status `75`.
- Closes #44; PR #45 already supplied the issue's production systemd and non-blocking service-action fixes.
- Source paths: `internal/onepass/client_test.go`, `docs/configuration-reference.md`, `docs/troubleshooting.md`

## Scope Check
- Matches issue because: it closes the remaining documentation and regression-test gaps without changing the production behavior established by PR #45.
- Changed file groups: provider client tests verify classification and retry behavior; operator documentation explains the existing service policy and recovery procedure.
- Out of scope / deferred: service dependency redesign, exit-policy changes, live systemd/provider integration, and unrelated error-handling options.

## Validation
- `nix develop -c go test ./internal/onepass -run TestResolveSecretDoesNotRetryRateLimit -count=1` passed.
- `nix develop -c go test ./... -count=1` passed.
- `nix flake check` passed.
- `git diff --check` passed.
- Independent pre-PR review found one inaccurate reset-timestamp claim; corrected before commit, with no remaining blocking findings.

## Follow-ups
- None.