### PR TITLE
feat(nixos): add automatic secret polling

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -182,6 +182,36 @@ services.onepassword-secrets.systemdIntegration = {
 };
 ```
 
+#### Automatic Secret Polling
+
+The path watcher only observes local file changes. Enable polling when OpNix
+must discover values changed remotely in 1Password:
+
+```nix
+services.onepassword-secrets.systemdIntegration = {
+  enable = true;
+  polling = {
+    enable = true;
+    interval = "6h";
+  };
+};
+```
+
+Boot-time retrieval remains immediate. The first timer poll runs after the
+configured interval, then repeats at that cadence. Each poll uses the normal
+content-based change detection, so managed services are restarted only when a
+materialized secret changes.
+
+Use a longer interval to reduce provider traffic. A failed poll is visible in
+`opnix-secrets-poll.service` logs and waits for the next timer activation; exit
+status `75` still indicates 1Password rate limiting. To trigger one poll after
+the rate limit clears:
+
+```bash
+sudo systemctl start opnix-secrets-poll.service
+sudo journalctl -u opnix-secrets-poll.service --since "10 minutes ago"
+```
+
 ### System Resource Management
 
 #### Memory Usage

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -271,6 +271,10 @@ services.onepassword-secrets.systemdIntegration = {
   services = ["caddy" "postgresql"];
   restartOnChange = true;
   changeDetection.enable = true;
+  polling = {
+    enable = true;
+    interval = "6h";
+  };
 };
 ```
 
@@ -306,6 +310,30 @@ services.onepassword-secrets.systemdIntegration = {
 - **Type**: `str`
 - **Default**: `"/var/lib/opnix/secret-hashes.json"`
 - **Description**: File to store secret content hashes for change detection
+
+#### `polling`
+- **Type**: `pollingOptions`
+- **Default**: `{}`
+- **Description**: NixOS-only automatic polling for remote 1Password changes
+
+##### `polling.enable`
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: Enable periodic secret retrieval through `opnix-secrets-poll.timer`
+
+##### `polling.interval`
+- **Type**: `str`
+- **Default**: `"6h"`
+- **Description**: A systemd time span used for both the first poll after boot and subsequent polls
+- **Example**: `"30min"`
+
+The normal boot-time `opnix-secrets.service` still retrieves secrets immediately.
+Polling uses a separate repeatable oneshot and the existing content hashes, so
+unchanged values do not restart managed services. Failed polls are recorded in
+journald and are retried at the next configured interval rather than in a tight
+loop. The local path watcher is suspended during each poll and restored when it
+finishes, preventing OpNix's own file operations from scheduling a duplicate
+retrieval.
 
 #### `errorHandling`
 - **Type**: `errorHandlingOptions`

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       };
 
       checks =
-        import ./nix/checks.nix {inherit pkgs src vendorHash;}
+        import ./nix/checks.nix {inherit pkgs nixpkgs system src vendorHash;}
         // {
           build = buildOpnix;
         };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,8 +1,11 @@
 {
   pkgs,
+  nixpkgs,
+  system,
   src,
   vendorHash,
-}: {
+}:
+{
   # Run tests
   go-tests = pkgs.buildGoModule {
     pname = "opnix-go-tests";
@@ -73,3 +76,39 @@
       touch $out
     '';
 }
+// pkgs.lib.optionalAttrs pkgs.stdenv.isLinux (let
+  nixosConfig = polling:
+    (nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        ./module.nix
+        {
+          system.stateVersion = "26.05";
+          services.onepassword-secrets = {
+            enable = true;
+            secrets.testSecret.reference = "op://Example/Service/password";
+            systemdIntegration.polling = polling;
+          };
+        }
+      ];
+    }).config;
+
+  defaultPollingConfig = nixosConfig {};
+  enabledPollingConfig = nixosConfig {
+    enable = true;
+    interval = "45min";
+  };
+in {
+  module-evaluation = assert !(defaultPollingConfig.systemd.services ? opnix-secrets-poll);
+  assert !(defaultPollingConfig.systemd.timers ? opnix-secrets-poll);
+  assert enabledPollingConfig.systemd.services.opnix-secrets-poll.serviceConfig.Type == "oneshot";
+  assert !(enabledPollingConfig.systemd.services.opnix-secrets-poll.serviceConfig ? RemainAfterExit);
+  assert nixpkgs.lib.hasInfix "systemctl stop opnix-secrets-watcher.path" enabledPollingConfig.systemd.services.opnix-secrets-poll.script;
+  assert nixpkgs.lib.hasInfix "trap restore_watcher EXIT" enabledPollingConfig.systemd.services.opnix-secrets-poll.script;
+  assert enabledPollingConfig.systemd.timers.opnix-secrets-poll.timerConfig.OnActiveSec == "45min";
+  assert enabledPollingConfig.systemd.timers.opnix-secrets-poll.timerConfig.OnUnitActiveSec == "45min";
+  assert enabledPollingConfig.systemd.timers.opnix-secrets-poll.timerConfig.Unit == "opnix-secrets-poll.service";
+    pkgs.runCommand "opnix-module-evaluation" {} ''
+      touch $out
+    '';
+})

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -260,6 +260,27 @@ in {
             description = "Change detection configuration";
           };
 
+          polling = lib.mkOption {
+            type = lib.types.submodule {
+              options = {
+                enable = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Periodically retrieve secrets from 1Password";
+                };
+
+                interval = lib.mkOption {
+                  type = lib.types.str;
+                  default = "6h";
+                  description = "Systemd time span between automatic secret retrievals";
+                  example = "30min";
+                };
+              };
+            };
+            default = {};
+            description = "Automatic 1Password polling configuration";
+          };
+
           errorHandling = lib.mkOption {
             type = lib.types.submodule {
               options = {
@@ -359,6 +380,89 @@ in {
         cfg.configFiles
         ++ (lib.optional hasDeclarativeSecrets declarativeConfigFile)
       );
+
+      processSecretsScript = ''
+        # Ensure output directory exists with correct permissions
+        mkdir -p ${cfg.outputDir}
+        chmod 751 ${cfg.outputDir}
+
+        # Create systemd integration directories if needed
+        ${lib.optionalString cfg.systemdIntegration.enable (
+          lib.optionalString cfg.systemdIntegration.changeDetection.enable ''
+            mkdir -p $(dirname ${cfg.systemdIntegration.changeDetection.hashFile})
+            chmod 755 $(dirname ${cfg.systemdIntegration.changeDetection.hashFile})
+          ''
+        )}
+
+        # Set up token file with correct group permissions if it exists
+        if [ -f ${cfg.tokenFile} ]; then
+          # Ensure token file has correct ownership and permissions
+          chown root:${opnixGroup} ${cfg.tokenFile}
+          chmod 640 ${cfg.tokenFile}
+        fi
+
+        # Handle missing token file gracefully - don't fail system boot
+        if [ ! -f ${cfg.tokenFile} ]; then
+          echo "WARNING: Token file ${cfg.tokenFile} does not exist!" >&2
+          echo "INFO: Using existing secrets, skipping updates" >&2
+          echo "INFO: Run 'opnix token set' to configure the token" >&2
+          exit 0
+        fi
+
+        # Validate token file permissions
+        if [ ! -r ${cfg.tokenFile} ]; then
+          echo "ERROR: Token file ${cfg.tokenFile} is not readable!" >&2
+          echo "INFO: Check file permissions or group membership" >&2
+          exit 1
+        fi
+
+        # Validate token is not empty
+        if [ ! -s ${cfg.tokenFile} ]; then
+          echo "ERROR: Token file is empty!" >&2
+          echo "INFO: Run 'opnix token set' to configure the token" >&2
+          exit 1
+        fi
+
+        # Run the secrets retrieval tool for each config file
+        ${lib.concatMapStringsSep "\n" (configFile: ''
+            echo "Processing config file: ${configFile}"
+            ${pkgsWithOverlay.opnix}/bin/opnix secret \
+              -token-file ${cfg.tokenFile} \
+              -config ${configFile} \
+              -output ${cfg.outputDir}
+          '')
+          allConfigFiles}
+
+        ${lib.optionalString cfg.systemdIntegration.enable ''
+          echo "INFO: Systemd integration enabled - services will be managed automatically"
+        ''}
+      '';
+
+      pollSecretsScript = ''
+        ${lib.optionalString cfg.systemdIntegration.changeDetection.enable ''
+          watcher_was_active=false
+          if ${pkgs.systemd}/bin/systemctl is-active --quiet opnix-secrets-watcher.path; then
+            ${pkgs.systemd}/bin/systemctl stop opnix-secrets-watcher.path
+            watcher_was_active=true
+          fi
+
+          restore_watcher() {
+            poll_status=$?
+            if [ "$watcher_was_active" = true ]; then
+              if ! ${pkgs.systemd}/bin/systemctl start opnix-secrets-watcher.path; then
+                echo "ERROR: Failed to restore opnix-secrets-watcher.path" >&2
+                if [ "$poll_status" -eq 0 ]; then
+                  poll_status=1
+                fi
+              fi
+            fi
+            exit "$poll_status"
+          }
+          trap restore_watcher EXIT
+        ''}
+
+        ${processSecretsScript}
+      '';
     in
       lib.mkMerge [
         # Validation assertions
@@ -412,62 +516,7 @@ in {
               Group = opnixGroup;
             };
 
-            script = ''
-              # Ensure output directory exists with correct permissions
-              mkdir -p ${cfg.outputDir}
-              chmod 751 ${cfg.outputDir}
-
-              # Create systemd integration directories if needed
-              ${lib.optionalString cfg.systemdIntegration.enable (
-                lib.optionalString cfg.systemdIntegration.changeDetection.enable ''
-                  mkdir -p $(dirname ${cfg.systemdIntegration.changeDetection.hashFile})
-                  chmod 755 $(dirname ${cfg.systemdIntegration.changeDetection.hashFile})
-                ''
-              )}
-
-              # Set up token file with correct group permissions if it exists
-              if [ -f ${cfg.tokenFile} ]; then
-                # Ensure token file has correct ownership and permissions
-                chown root:${opnixGroup} ${cfg.tokenFile}
-                chmod 640 ${cfg.tokenFile}
-              fi
-
-              # Handle missing token file gracefully - don't fail system boot
-              if [ ! -f ${cfg.tokenFile} ]; then
-                echo "WARNING: Token file ${cfg.tokenFile} does not exist!" >&2
-                echo "INFO: Using existing secrets, skipping updates" >&2
-                echo "INFO: Run 'opnix token set' to configure the token" >&2
-                exit 0
-              fi
-
-              # Validate token file permissions
-              if [ ! -r ${cfg.tokenFile} ]; then
-                echo "ERROR: Token file ${cfg.tokenFile} is not readable!" >&2
-                echo "INFO: Check file permissions or group membership" >&2
-                exit 1
-              fi
-
-              # Validate token is not empty
-              if [ ! -s ${cfg.tokenFile} ]; then
-                echo "ERROR: Token file is empty!" >&2
-                echo "INFO: Run 'opnix token set' to configure the token" >&2
-                exit 1
-              fi
-
-              # Run the secrets retrieval tool for each config file
-              ${lib.concatMapStringsSep "\n" (configFile: ''
-                  echo "Processing config file: ${configFile}"
-                  ${pkgsWithOverlay.opnix}/bin/opnix secret \
-                    -token-file ${cfg.tokenFile} \
-                    -config ${configFile} \
-                    -output ${cfg.outputDir}
-                '')
-                allConfigFiles}
-
-              ${lib.optionalString cfg.systemdIntegration.enable ''
-                echo "INFO: Systemd integration enabled - services will be managed automatically"
-              ''}
-            '';
+            script = processSecretsScript;
           };
         }
 
@@ -524,8 +573,34 @@ in {
                 '';
               };
             };
+
+            pollingService = lib.optionalAttrs cfg.systemdIntegration.polling.enable {
+              opnix-secrets-poll = {
+                description = "Poll 1Password for OpNix secret changes";
+                after = ["network-online.target" "nss-lookup.target"];
+                wants = ["network-online.target" "nss-lookup.target"];
+                serviceConfig = {
+                  Type = "oneshot";
+                  User = "root";
+                  Group = opnixGroup;
+                };
+                script = pollSecretsScript;
+              };
+            };
           in
-            serviceConfigs // restartService;
+            serviceConfigs // restartService // pollingService;
+
+          systemd.timers = lib.mkIf cfg.systemdIntegration.polling.enable {
+            opnix-secrets-poll = {
+              description = "Periodically poll 1Password for OpNix secret changes";
+              wantedBy = ["timers.target"];
+              timerConfig = {
+                OnActiveSec = cfg.systemdIntegration.polling.interval;
+                OnUnitActiveSec = cfg.systemdIntegration.polling.interval;
+                Unit = "opnix-secrets-poll.service";
+              };
+            };
+          };
 
           # Create a systemd path unit for change detection if enabled
           systemd.paths = lib.mkIf cfg.systemdIntegration.changeDetection.enable {


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Linear
- Issue: https://linear.app/brizzbuzz/issue/MMI-926/add-automatic-opnix-secret-polling

## Summary
- Add disabled-by-default NixOS polling with a configurable systemd interval and a dedicated repeatable oneshot.
- Reuse OpNix's existing retrieval and content-hash service-action path while suspending the local path watcher during polls to prevent duplicate provider requests.
- Add Linux module-evaluation coverage and operator documentation for cadence, failures, rate limits, and manual polling.
- Closes #29.
- Source paths: `nix/module.nix`, `nix/checks.nix`, `flake.nix`, `docs/configuration-reference.md`, `docs/best-practices.md`

## Scope Check
- Matches issue because: NixOS can now discover remote 1Password changes on a configured timer, while unchanged content retains the existing no-restart behavior.
- Changed file groups: NixOS module options/units implement polling; flake checks assert disabled and enabled unit generation; documentation defines configuration and operations.
- Out of scope / deferred: `onlyWhenServicesActive`, provider backoff changes, Darwin/Home Manager polling, and path-watcher redesign.

## Validation
- `nix develop -c go test ./... -count=1` passed.
- `nix flake check` passed, including build, Go tests, lint, Nix formatting, and module evaluation.
- `nix flake check --no-build --all-systems` passed for all four default systems.
- `git diff --check` passed.
- Three review passes found and resolved timer cadence, duplicate watcher-triggered retrieval, and Darwin check-export defects; final review found no remaining issues.
- Residual risk: generated unit behavior is evaluation-tested but not exercised in a live NixOS VM test.

## Follow-ups
- None. The requested `onlyWhenServicesActive` behavior remains deferred until its empty and multi-service semantics are defined.