### PR TITLE
feat(secrets): support binary 1Password files

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -118,6 +118,11 @@ services.onepassword-secrets.secrets = {
       owner = "caddy";
       mode = "0644";
     };
+    encryptedKey = {
+      reference = "op://Homelab/Keys/server.age";
+      kind = "file";
+      path = "/etc/keys/server.age";
+    };
   };
 ```
 
@@ -135,6 +140,12 @@ Each secret in the `secrets` attribute set supports these options:
 - **Type**: `str`
 - **Description**: 1Password reference in the format `op://Vault/Item/field` or `op://Vault/Item/Section/field`
 - **Example**: `"op://Homelab/Database/password"` or `"op://Homelab/SSL Certs/example.com/cert"`
+
+#### `kind`
+- **Type**: `enum ["field" "file"]`
+- **Default**: `"field"`
+- **Description**: Resolve a text field or download a Document/attachment as raw bytes
+- **Notes**: File references use exactly `op://Vault/Item/filename`; see [Binary Documents and Attachments](#binary-documents-and-attachments)
 
 #### `path`
 - **Type**: `nullOr str`
@@ -395,7 +406,8 @@ programs.onepassword-secrets = {
 ```nix
 programs.onepassword-secrets.secrets = {
   sshPrivateKey = {
-    reference = "op://Personal/SSH/private-key";
+    reference = "op://Personal/SSH/id_ed25519";
+    kind = "file";
     path = ".ssh/id_rsa";
     mode = "0600";
   };
@@ -408,6 +420,11 @@ programs.onepassword-secrets.secrets = {
 - **Type**: `str`
 - **Description**: 1Password reference
 - **Example**: `"op://Personal/SSH/private-key"`
+
+#### `kind`
+- **Type**: `enum ["field" "file"]`
+- **Default**: `"field"`
+- **Description**: Resolve a text field or download a Document/attachment as raw bytes
 
 #### `path`
 - **Type**: `nullOr str`
@@ -452,6 +469,12 @@ When using `configFiles`, each JSON file should follow this structure:
       "owner": "caddy",
       "group": "caddy",
       "mode": "0644"
+    },
+    {
+      "path": "keys/server.age",
+      "reference": "op://Vault/Keys/server.age",
+      "kind": "file",
+      "mode": "0600"
     }
   ]
 }
@@ -462,6 +485,7 @@ When using `configFiles`, each JSON file should follow this structure:
 - `reference`: 1Password reference
 
 **Optional fields:**
+- `kind`: `"field"` (default) or `"file"`
 - `owner`: File owner (default: "root" for system, username for Home Manager)
 - `group`: File group (default: "root" for system, "users" for Home Manager)
 - `mode`: File permissions (default: "0600")
@@ -483,6 +507,27 @@ op://VaultName/ItemName/FieldName
 - `username`: The item's username field
 - `notes`: The item's notes field
 - Custom field names as defined in 1Password
+
+### Binary Documents and Attachments
+
+Set `kind = "file"` to retrieve bytes through the 1Password SDK file API. This
+supports both Document-category items and files attached to ordinary items. The
+reference must have exactly three components:
+
+```text
+op://Vault/Item/filename
+```
+
+Vault and item selectors match an exact title or ID. The filename matches the
+Document name or attachment name exactly. Missing and ambiguous selectors fail
+with exit status `65`; OpNix never falls back from field resolution to file
+resolution automatically. Percent-encode special characters within individual
+components.
+
+All field and file references are resolved before any secret file is written,
+so a failed download leaves existing files unchanged. File contents remain raw
+bytes for materialization and change detection. The 1Password SDK limits file
+operations to 50 MB; larger files are not supported.
 
 ## Secret Path References
 

--- a/docs/examples/basic-home-manager.md
+++ b/docs/examples/basic-home-manager.md
@@ -60,7 +60,8 @@ Fields:
     secrets = {
       # SSH private key
       sshPrivateKey = {
-        reference = "op://Personal/SSH-Key-Main/private-key";
+        reference = "op://Personal/SSH-Key-Main/id_rsa";
+        kind = "file";
         path = ".ssh/id_rsa";
         mode = "0600";
       };

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,8 @@ programs.onepassword-secrets = {
   
   secrets = {
     sshPrivateKey = {
-      reference = "op://Personal/SSH/private-key";
+      reference = "op://Personal/SSH/id_ed25519";
+      kind = "file";
       path = ".ssh/id_rsa";
       mode = "0600";
     };

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,9 +8,17 @@ import (
 	"github.com/brizzbuzz/opnix/internal/validation"
 )
 
+type SecretKind string
+
+const (
+	SecretKindField SecretKind = "field"
+	SecretKindFile  SecretKind = "file"
+)
+
 type Secret struct {
 	Path      string            `json:"path"`
 	Reference string            `json:"reference"`
+	Kind      SecretKind        `json:"kind,omitempty"`
 	Owner     string            `json:"owner,omitempty"`
 	Group     string            `json:"group,omitempty"`
 	Mode      string            `json:"mode,omitempty"`
@@ -52,6 +60,7 @@ func (c *Config) convertToValidationSecrets() []validation.SecretData {
 		secrets[i] = validation.SecretData{
 			Path:         s.Path,
 			Reference:    s.Reference,
+			Kind:         string(s.Kind),
 			Owner:        s.Owner,
 			Group:        s.Group,
 			Mode:         s.Mode,
@@ -84,6 +93,11 @@ func Load(path string) (*Config, error) {
 			"Invalid JSON format in config file",
 			err,
 		)
+	}
+	for i := range config.Secrets {
+		if config.Secrets[i].Kind == "" {
+			config.Secrets[i].Kind = SecretKindField
+		}
 	}
 
 	// Validate the loaded configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,55 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadSecretKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		kindJSON string
+		want     SecretKind
+		wantErr  bool
+	}{
+		{name: "defaults to field", want: SecretKindField},
+		{name: "accepts field", kindJSON: `, "kind": "field"`, want: SecretKindField},
+		{name: "accepts file", kindJSON: `, "kind": "file"`, want: SecretKindFile},
+		{name: "rejects unknown kind", kindJSON: `, "kind": "document"`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.json")
+			configData := `{"secrets":[{"path":"test/secret","reference":"op://vault/item/value"` + tt.kindJSON + `}]}`
+			if err := os.WriteFile(configPath, []byte(configData), 0600); err != nil {
+				t.Fatalf("Failed to write config: %v", err)
+			}
+
+			cfg, err := Load(configPath)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Expected invalid kind error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			if got := cfg.Secrets[0].Kind; got != tt.want {
+				t.Fatalf("Expected kind %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestLoadFileKindRequiresFilenameReference(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	configData := `{"secrets":[{"path":"test/file","reference":"op://vault/item/section/file.bin","kind":"file"}]}`
+	if err := os.WriteFile(configPath, []byte(configData), 0600); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	if _, err := Load(configPath); err == nil {
+		t.Fatal("Expected file reference with more than three components to fail validation")
+	}
+}
+
 func TestLoadMultiple(t *testing.T) {
 	// Create temp config files
 	tmpDir, err := os.MkdirTemp("", "opnix-tests-*")

--- a/internal/onepass/client.go
+++ b/internal/onepass/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -22,22 +23,50 @@ type sdkSecretsAPI interface {
 	ResolveAll(context.Context, []string) (onepassword.ResolveAllResponse, error)
 }
 
+type sdkVaultsAPI interface {
+	List(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error)
+}
+
+type sdkItemsAPI interface {
+	Get(context.Context, string, string) (onepassword.Item, error)
+	List(context.Context, string, ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error)
+}
+
+type sdkFilesAPI interface {
+	Read(context.Context, string, string, onepassword.FileAttributes) ([]byte, error)
+}
+
+type sdkAPIs struct {
+	secrets sdkSecretsAPI
+	vaults  sdkVaultsAPI
+	items   sdkItemsAPI
+	files   sdkFilesAPI
+}
+
 type Client struct {
 	secrets sdkSecretsAPI
+	vaults  sdkVaultsAPI
+	items   sdkItemsAPI
+	files   sdkFilesAPI
 }
 
 var (
-	newSDKSecrets = func(ctx context.Context, token string) (sdkSecretsAPI, error) {
+	newSDKClient = func(ctx context.Context, token string) (sdkAPIs, error) {
 		client, err := onepassword.NewClient(
 			ctx,
 			onepassword.WithServiceAccountToken(token),
 			onepassword.WithIntegrationInfo("NixOS Secrets Integration", "v1.0.0"),
 		)
 		if err != nil {
-			return nil, err
+			return sdkAPIs{}, err
 		}
-
-		return client.Secrets(), nil
+		items := client.Items()
+		return sdkAPIs{
+			secrets: client.Secrets(),
+			vaults:  client.Vaults(),
+			items:   items,
+			files:   items.Files(),
+		}, nil
 	}
 	retrySleep = time.Sleep
 )
@@ -83,8 +112,8 @@ func NewClient(tokenFile string) (*Client, error) {
 		return nil, err
 	}
 
-	secretsAPI, err := retryOperation(defaultInitAttempts, "Initializing 1Password client", func() (sdkSecretsAPI, error) {
-		return newSDKSecrets(context.Background(), token)
+	apis, err := retryOperation(defaultInitAttempts, "Initializing 1Password client", func() (sdkAPIs, error) {
+		return newSDKClient(context.Background(), token)
 	})
 	if err != nil {
 		return nil, errors.OnePasswordError(
@@ -94,7 +123,7 @@ func NewClient(tokenFile string) (*Client, error) {
 		)
 	}
 
-	return &Client{secrets: secretsAPI}, nil
+	return &Client{secrets: apis.secrets, vaults: apis.vaults, items: apis.items, files: apis.files}, nil
 }
 
 func (c *Client) ResolveSecret(reference string) (string, error) {
@@ -151,6 +180,173 @@ func (c *Client) ResolveSecrets(references []string) (map[string]string, error) 
 	}
 
 	return resolved, nil
+}
+
+func (c *Client) ResolveFiles(references []string) (map[string][]byte, error) {
+	ctx := context.Background()
+	vaults, err := retryOperation(defaultResolveAttempts, "Listing 1Password vaults", func() ([]onepassword.VaultOverview, error) {
+		return c.vaults.List(ctx)
+	}, shouldRetryProviderError)
+	if err != nil {
+		return nil, errors.OnePasswordError(
+			"Resolving 1Password files",
+			"Failed to list 1Password vaults",
+			classifyTopLevelProviderError(err),
+		)
+	}
+
+	resolved := make(map[string][]byte, len(references))
+	itemsByVault := make(map[string][]onepassword.ItemOverview)
+	itemCache := make(map[string]onepassword.Item)
+	var failures []*errors.ProviderError
+
+	for _, reference := range references {
+		vaultSelector, itemSelector, fileSelector, parseErr := parseFileReference(reference)
+		if parseErr != nil {
+			failures = append(failures, &errors.ProviderError{
+				Kind: errors.ProviderErrorInvalidReference, Reference: reference, Issue: parseErr.Error(),
+			})
+			continue
+		}
+
+		vault, failure := matchVault(reference, vaultSelector, vaults)
+		if failure != nil {
+			failures = append(failures, failure)
+			continue
+		}
+
+		itemOverviews, ok := itemsByVault[vault.ID]
+		if !ok {
+			itemOverviews, err = retryOperation(defaultResolveAttempts, "Listing 1Password items", func() ([]onepassword.ItemOverview, error) {
+				return c.items.List(ctx, vault.ID)
+			}, shouldRetryProviderError)
+			if err != nil {
+				failures = append(failures, classifyFileProviderError(reference, "failed to list items", err))
+				continue
+			}
+			itemsByVault[vault.ID] = itemOverviews
+		}
+
+		itemOverview, failure := matchItem(reference, itemSelector, itemOverviews)
+		if failure != nil {
+			failures = append(failures, failure)
+			continue
+		}
+
+		cacheKey := vault.ID + "/" + itemOverview.ID
+		item, ok := itemCache[cacheKey]
+		if !ok {
+			item, err = retryOperation(defaultResolveAttempts, "Reading 1Password item", func() (onepassword.Item, error) {
+				return c.items.Get(ctx, vault.ID, itemOverview.ID)
+			}, shouldRetryProviderError)
+			if err != nil {
+				failures = append(failures, classifyFileProviderError(reference, "failed to read item", err))
+				continue
+			}
+			itemCache[cacheKey] = item
+		}
+
+		attributes, failure := matchFile(reference, fileSelector, item)
+		if failure != nil {
+			failures = append(failures, failure)
+			continue
+		}
+
+		content, readErr := retryOperation(defaultResolveAttempts, "Reading 1Password file", func() ([]byte, error) {
+			return c.files.Read(ctx, vault.ID, itemOverview.ID, attributes)
+		}, shouldRetryProviderError)
+		if readErr != nil {
+			failures = append(failures, classifyFileProviderError(reference, "failed to read file", readErr))
+			continue
+		}
+		resolved[reference] = content
+	}
+
+	if len(failures) > 0 {
+		return nil, &errors.ProviderResolutionError{Failures: failures}
+	}
+	return resolved, nil
+}
+
+func parseFileReference(reference string) (string, string, string, error) {
+	if !strings.HasPrefix(reference, "op://") {
+		return "", "", "", fmt.Errorf("file reference must use op://Vault/Item/filename")
+	}
+	parts := strings.Split(strings.TrimPrefix(reference, "op://"), "/")
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("file reference must contain exactly vault, item, and filename")
+	}
+	decoded := make([]string, len(parts))
+	for i, part := range parts {
+		value, err := url.PathUnescape(part)
+		if err != nil || value == "" {
+			return "", "", "", fmt.Errorf("file reference contains an invalid or empty component")
+		}
+		decoded[i] = value
+	}
+	return decoded[0], decoded[1], decoded[2], nil
+}
+
+func matchVault(reference, selector string, vaults []onepassword.VaultOverview) (onepassword.VaultOverview, *errors.ProviderError) {
+	var matches []onepassword.VaultOverview
+	for _, vault := range vaults {
+		if vault.ID == selector || vault.Title == selector {
+			matches = append(matches, vault)
+		}
+	}
+	if len(matches) == 0 {
+		return onepassword.VaultOverview{}, &errors.ProviderError{Kind: errors.ProviderErrorMissingReference, Reference: reference, Issue: "vault not found"}
+	}
+	if len(matches) > 1 {
+		return onepassword.VaultOverview{}, &errors.ProviderError{Kind: errors.ProviderErrorAmbiguousReference, Reference: reference, Issue: "multiple vaults match exactly"}
+	}
+	return matches[0], nil
+}
+
+func matchItem(reference, selector string, items []onepassword.ItemOverview) (onepassword.ItemOverview, *errors.ProviderError) {
+	var matches []onepassword.ItemOverview
+	for _, item := range items {
+		if item.ID == selector || item.Title == selector {
+			matches = append(matches, item)
+		}
+	}
+	if len(matches) == 0 {
+		return onepassword.ItemOverview{}, &errors.ProviderError{Kind: errors.ProviderErrorMissingReference, Reference: reference, Issue: "item not found"}
+	}
+	if len(matches) > 1 {
+		return onepassword.ItemOverview{}, &errors.ProviderError{Kind: errors.ProviderErrorAmbiguousReference, Reference: reference, Issue: "multiple items match exactly"}
+	}
+	return matches[0], nil
+}
+
+func matchFile(reference, selector string, item onepassword.Item) (onepassword.FileAttributes, *errors.ProviderError) {
+	matches := make(map[string]onepassword.FileAttributes)
+	if item.Document != nil && item.Document.Name == selector {
+		matches[item.Document.ID] = *item.Document
+	}
+	for _, file := range item.Files {
+		if file.Attributes.Name == selector {
+			matches[file.Attributes.ID] = file.Attributes
+		}
+	}
+	if len(matches) == 0 {
+		return onepassword.FileAttributes{}, &errors.ProviderError{Kind: errors.ProviderErrorMissingReference, Reference: reference, Issue: "file not found"}
+	}
+	if len(matches) > 1 {
+		return onepassword.FileAttributes{}, &errors.ProviderError{Kind: errors.ProviderErrorAmbiguousReference, Reference: reference, Issue: "multiple files have this filename"}
+	}
+	for _, attributes := range matches {
+		return attributes, nil
+	}
+	panic("unreachable")
+}
+
+func classifyFileProviderError(reference, operation string, err error) *errors.ProviderError {
+	var rateLimited *onepassword.RateLimitExceededError
+	if stderrors.As(err, &rateLimited) {
+		return &errors.ProviderError{Kind: errors.ProviderErrorRateLimited, Reference: reference, Issue: "1Password rate limit exceeded", Cause: err}
+	}
+	return &errors.ProviderError{Kind: errors.ProviderErrorTransient, Reference: reference, Issue: operation, Cause: err}
 }
 
 func retryOperation[T any](attempts int, operation string, fn func() (T, error), shouldRetry ...func(error) bool) (T, error) {
@@ -212,6 +408,8 @@ func classifyResolveReferenceError(reference string, err onepassword.ResolveRefe
 		onepassword.ResolveReferenceErrorTypeVariantTooManyItems,
 		onepassword.ResolveReferenceErrorTypeVariantTooManyMatchingFields:
 		return &errors.ProviderError{Kind: errors.ProviderErrorAmbiguousReference, Reference: reference, Issue: string(err.Type)}
+	case onepassword.ResolveReferenceErrorTypeVariantUnsupportedFileFormat:
+		return &errors.ProviderError{Kind: errors.ProviderErrorOther, Reference: reference, Issue: `unsupported file format; configure this secret with kind = "file"`}
 	default:
 		return &errors.ProviderError{Kind: errors.ProviderErrorOther, Reference: reference, Issue: string(err.Type)}
 	}

--- a/internal/onepass/client_test.go
+++ b/internal/onepass/client_test.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +16,35 @@ import (
 type fakeSecretsAPI struct {
 	resolve    func(context.Context, string) (string, error)
 	resolveAll func(context.Context, []string) (onepassword.ResolveAllResponse, error)
+}
+
+type fakeVaultsAPI struct {
+	list func(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error)
+}
+
+func (f fakeVaultsAPI) List(ctx context.Context, params ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error) {
+	return f.list(ctx, params...)
+}
+
+type fakeItemsAPI struct {
+	list func(context.Context, string, ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error)
+	get  func(context.Context, string, string) (onepassword.Item, error)
+}
+
+func (f fakeItemsAPI) List(ctx context.Context, vaultID string, filters ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error) {
+	return f.list(ctx, vaultID, filters...)
+}
+
+func (f fakeItemsAPI) Get(ctx context.Context, vaultID, itemID string) (onepassword.Item, error) {
+	return f.get(ctx, vaultID, itemID)
+}
+
+type fakeFilesAPI struct {
+	read func(context.Context, string, string, onepassword.FileAttributes) ([]byte, error)
+}
+
+func (f fakeFilesAPI) Read(ctx context.Context, vaultID, itemID string, attr onepassword.FileAttributes) ([]byte, error) {
+	return f.read(ctx, vaultID, itemID, attr)
 }
 
 func (f fakeSecretsAPI) Resolve(ctx context.Context, reference string) (string, error) {
@@ -93,10 +123,10 @@ func TestGetToken(t *testing.T) {
 }
 
 func TestNewClientRetriesTransientInitializationFailures(t *testing.T) {
-	originalNewSDKSecrets := newSDKSecrets
+	originalNewSDKClient := newSDKClient
 	originalRetrySleep := retrySleep
 	t.Cleanup(func() {
-		newSDKSecrets = originalNewSDKSecrets
+		newSDKClient = originalNewSDKClient
 		retrySleep = originalRetrySleep
 		os.Unsetenv("OP_SERVICE_ACCOUNT_TOKEN")
 	})
@@ -105,17 +135,17 @@ func TestNewClientRetriesTransientInitializationFailures(t *testing.T) {
 	retrySleep = func(_ time.Duration) {}
 
 	attempts := 0
-	newSDKSecrets = func(_ context.Context, token string) (sdkSecretsAPI, error) {
+	newSDKClient = func(_ context.Context, token string) (sdkAPIs, error) {
 		attempts++
 		if token != "ops_test_token" {
 			t.Fatalf("expected token to be passed through")
 		}
 		if attempts < 3 {
-			return nil, stderrors.New("transient auth failure")
+			return sdkAPIs{}, stderrors.New("transient auth failure")
 		}
-		return fakeSecretsAPI{resolve: func(_ context.Context, reference string) (string, error) {
+		return sdkAPIs{secrets: fakeSecretsAPI{resolve: func(_ context.Context, reference string) (string, error) {
 			return "resolved:" + reference, nil
-		}}, nil
+		}}}, nil
 	}
 
 	client, err := NewClient("")
@@ -224,5 +254,141 @@ func TestResolveSecretDoesNotRetryRateLimit(t *testing.T) {
 	}
 	if code := opnixerrors.ExitCode(err); code != opnixerrors.ExitCodeRateLimited {
 		t.Fatalf("expected exit code %d, got %d", opnixerrors.ExitCodeRateLimited, code)
+	}
+}
+
+func TestResolveFilesReadsDocumentsAndAttachments(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference string
+		vault     onepassword.VaultOverview
+		overview  onepassword.ItemOverview
+		item      onepassword.Item
+		wantAttr  onepassword.FileAttributes
+	}{
+		{
+			name:      "document by titles",
+			reference: "op://Personal/SSH%20Key/id_ed25519",
+			vault:     onepassword.VaultOverview{ID: "vault-id", Title: "Personal"},
+			overview:  onepassword.ItemOverview{ID: "document-id", Title: "SSH Key"},
+			item: onepassword.Item{ID: "document-id", Title: "SSH Key", Document: &onepassword.FileAttributes{
+				ID: "document-file-id", Name: "id_ed25519", Size: 6,
+			}},
+			wantAttr: onepassword.FileAttributes{ID: "document-file-id", Name: "id_ed25519", Size: 6},
+		},
+		{
+			name:      "attachment by vault and item IDs",
+			reference: "op://vault-id/item-id/client.p12",
+			vault:     onepassword.VaultOverview{ID: "vault-id", Title: "Certificates"},
+			overview:  onepassword.ItemOverview{ID: "item-id", Title: "Client Certificate"},
+			item: onepassword.Item{ID: "item-id", Title: "Client Certificate", Files: []onepassword.ItemFile{{
+				Attributes: onepassword.FileAttributes{ID: "attachment-id", Name: "client.p12", Size: 6},
+			}}},
+			wantAttr: onepassword.FileAttributes{ID: "attachment-id", Name: "client.p12", Size: 6},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := []byte{0x00, 0xff, 0xfe, 0x80, 0x01, '\n'}
+			client := &Client{
+				vaults: fakeVaultsAPI{list: func(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error) {
+					return []onepassword.VaultOverview{tt.vault}, nil
+				}},
+				items: fakeItemsAPI{
+					list: func(_ context.Context, vaultID string, _ ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error) {
+						if vaultID != tt.vault.ID {
+							t.Fatalf("Unexpected vault ID %q", vaultID)
+						}
+						return []onepassword.ItemOverview{tt.overview}, nil
+					},
+					get: func(_ context.Context, vaultID, itemID string) (onepassword.Item, error) {
+						if vaultID != tt.vault.ID || itemID != tt.overview.ID {
+							t.Fatalf("Unexpected item lookup %q/%q", vaultID, itemID)
+						}
+						return tt.item, nil
+					},
+				},
+				files: fakeFilesAPI{read: func(_ context.Context, vaultID, itemID string, attr onepassword.FileAttributes) ([]byte, error) {
+					if vaultID != tt.vault.ID || itemID != tt.overview.ID || attr != tt.wantAttr {
+						t.Fatalf("Unexpected file read %q/%q %#v", vaultID, itemID, attr)
+					}
+					return want, nil
+				}},
+			}
+
+			resolved, err := client.ResolveFiles([]string{tt.reference})
+			if err != nil {
+				t.Fatalf("Failed to resolve file: %v", err)
+			}
+			if got := resolved[tt.reference]; string(got) != string(want) {
+				t.Fatalf("File bytes changed: got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestResolveFilesClassifiesSelectorFailures(t *testing.T) {
+	t.Run("ambiguous vault", func(t *testing.T) {
+		client := &Client{vaults: fakeVaultsAPI{list: func(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error) {
+			return []onepassword.VaultOverview{{ID: "one", Title: "Shared"}, {ID: "two", Title: "Shared"}}, nil
+		}}}
+		_, err := client.ResolveFiles([]string{"op://Shared/Item/file.bin"})
+		if err == nil || opnixerrors.ExitCode(err) != opnixerrors.ExitCodeMissingReference {
+			t.Fatalf("Expected ambiguous reference exit %d, got %v", opnixerrors.ExitCodeMissingReference, err)
+		}
+	})
+
+	t.Run("rate limit", func(t *testing.T) {
+		attempts := 0
+		client := &Client{vaults: fakeVaultsAPI{list: func(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error) {
+			attempts++
+			return nil, &onepassword.RateLimitExceededError{}
+		}}}
+		_, err := client.ResolveFiles([]string{"op://Vault/Item/file.bin"})
+		if err == nil || opnixerrors.ExitCode(err) != opnixerrors.ExitCodeRateLimited {
+			t.Fatalf("Expected rate-limit exit %d, got %v", opnixerrors.ExitCodeRateLimited, err)
+		}
+		if attempts != 1 {
+			t.Fatalf("Expected one rate-limited attempt, got %d", attempts)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		client := &Client{
+			vaults: fakeVaultsAPI{list: func(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error) {
+				return []onepassword.VaultOverview{{ID: "vault-id", Title: "Vault"}}, nil
+			}},
+			items: fakeItemsAPI{
+				list: func(context.Context, string, ...onepassword.ItemListFilter) ([]onepassword.ItemOverview, error) {
+					return []onepassword.ItemOverview{{ID: "item-id", Title: "Item"}}, nil
+				},
+				get: func(context.Context, string, string) (onepassword.Item, error) {
+					return onepassword.Item{ID: "item-id", Title: "Item"}, nil
+				},
+			},
+		}
+		_, err := client.ResolveFiles([]string{"op://Vault/Item/missing.bin"})
+		if err == nil || opnixerrors.ExitCode(err) != opnixerrors.ExitCodeMissingReference {
+			t.Fatalf("Expected missing reference exit %d, got %v", opnixerrors.ExitCodeMissingReference, err)
+		}
+	})
+
+	t.Run("invalid reference", func(t *testing.T) {
+		client := &Client{vaults: fakeVaultsAPI{list: func(context.Context, ...onepassword.VaultListParams) ([]onepassword.VaultOverview, error) {
+			return nil, nil
+		}}}
+		_, err := client.ResolveFiles([]string{"op://Vault/Item/Section/file.bin"})
+		if err == nil || opnixerrors.ExitCode(err) != opnixerrors.ExitCodeMissingReference {
+			t.Fatalf("Expected invalid reference exit %d, got %v", opnixerrors.ExitCodeMissingReference, err)
+		}
+	})
+}
+
+func TestUnsupportedFileFormatSuggestsFileKind(t *testing.T) {
+	sdkErr := onepassword.NewResolveReferenceErrorTypeVariantUnsupportedFileFormat()
+	err := classifyResolveReferenceError("op://Vault/Item/file.bin", sdkErr)
+	if !strings.Contains(err.Error(), `kind = "file"`) {
+		t.Fatalf("Expected file-kind guidance, got %v", err)
 	}
 }

--- a/internal/secrets/processor.go
+++ b/internal/secrets/processor.go
@@ -15,8 +15,8 @@ import (
 )
 
 type SecretClient interface {
-	ResolveSecret(reference string) (string, error)
 	ResolveSecrets(references []string) (map[string]string, error)
+	ResolveFiles(references []string) (map[string][]byte, error)
 }
 
 type ProcessResult struct {
@@ -56,6 +56,28 @@ func (p *Processor) Process(cfg *config.Config) (*ProcessResult, error) {
 		p.defaults = cfg.Defaults
 	}
 
+	result := &ProcessResult{
+		SecretPaths:    make(map[string]string),
+		ProcessedCount: 0,
+	}
+
+	fieldReferences, fileReferences := uniqueReferencesByKind(cfg.Secrets)
+	resolvedSecrets := make(map[string]string, len(fieldReferences))
+	if len(fieldReferences) > 0 {
+		var err error
+		resolvedSecrets, err = p.client.ResolveSecrets(fieldReferences)
+		if err != nil {
+			return nil, wrapResolutionError(err)
+		}
+	}
+	resolvedFiles := make(map[string][]byte, len(fileReferences))
+	if len(fileReferences) > 0 {
+		var err error
+		resolvedFiles, err = p.client.ResolveFiles(fileReferences)
+		if err != nil {
+			return nil, wrapResolutionError(err)
+		}
+	}
 	if err := os.MkdirAll(p.outputDir, 0755); err != nil {
 		return nil, errors.FileOperationError(
 			"Creating output directory",
@@ -65,41 +87,17 @@ func (p *Processor) Process(cfg *config.Config) (*ProcessResult, error) {
 		)
 	}
 
-	result := &ProcessResult{
-		SecretPaths:    make(map[string]string),
-		ProcessedCount: 0,
-	}
-
-	references := uniqueReferences(cfg.Secrets)
-	resolvedSecrets, err := p.client.ResolveSecrets(references)
-	if err != nil {
-		suggestions := []string{
-			"Check the failed 1Password references listed above",
-			"Create any missing vaults, items, or fields before restarting opnix-secrets.service",
-			"If rate-limited, wait for the 1Password reset window before retrying",
-		}
-		var resolutionErr *errors.ProviderResolutionError
-		if stderrors.As(err, &resolutionErr) {
-			for _, failure := range resolutionErr.Failures {
-				if failure.Kind == errors.ProviderErrorMissingReference {
-					suggestions = append(suggestions,
-						"If this service belongs to an older NixOS generation, restore any retired 1Password references until its rollback window closes",
-					)
-					break
-				}
-			}
-		}
-		return nil, errors.WrapWithSuggestions(
-			err,
-			"Resolving 1Password references",
-			"secret processing",
-			suggestions,
-		)
-	}
-
 	for i, secret := range cfg.Secrets {
 		secretName := fmt.Sprintf("secret[%d]:%s", i, secret.Path)
-		value, ok := resolvedSecrets[secret.Reference]
+		var value []byte
+		var ok bool
+		if secret.Kind == config.SecretKindFile {
+			value, ok = resolvedFiles[secret.Reference]
+		} else {
+			var fieldValue string
+			fieldValue, ok = resolvedSecrets[secret.Reference]
+			value = []byte(fieldValue)
+		}
 		if !ok {
 			return nil, errors.OnePasswordError(
 				fmt.Sprintf("Resolving secret %s", secretName),
@@ -129,7 +127,7 @@ func (p *Processor) Process(cfg *config.Config) (*ProcessResult, error) {
 	return result, nil
 }
 
-func (p *Processor) processSecret(secret config.Secret, secretName, value string) (string, error) {
+func (p *Processor) processSecret(secret config.Secret, secretName string, value []byte) (string, error) {
 	// Determine output path with enhanced path management
 	outputPath, err := p.resolveSecretPathWithTemplate(secret, secretName)
 	if err != nil {
@@ -168,7 +166,7 @@ func (p *Processor) processSecret(secret config.Secret, secretName, value string
 	}
 
 	// Write file with specified permissions
-	if err := os.WriteFile(outputPath, []byte(value), os.FileMode(fileMode)); err != nil {
+	if err := os.WriteFile(outputPath, value, os.FileMode(fileMode)); err != nil {
 		return "", errors.FileOperationError(
 			fmt.Sprintf("Writing secret file for %s", secretName),
 			outputPath,
@@ -202,17 +200,51 @@ func (p *Processor) processSecret(secret config.Secret, secretName, value string
 	return outputPath, nil
 }
 
-func uniqueReferences(secrets []config.Secret) []string {
-	seen := make(map[string]struct{}, len(secrets))
-	var references []string
+func uniqueReferencesByKind(secrets []config.Secret) ([]string, []string) {
+	seenFields := make(map[string]struct{}, len(secrets))
+	seenFiles := make(map[string]struct{}, len(secrets))
+	var fields, files []string
 	for _, secret := range secrets {
-		if _, ok := seen[secret.Reference]; ok {
+		if secret.Kind == config.SecretKindFile {
+			if _, ok := seenFiles[secret.Reference]; ok {
+				continue
+			}
+			seenFiles[secret.Reference] = struct{}{}
+			files = append(files, secret.Reference)
 			continue
 		}
-		seen[secret.Reference] = struct{}{}
-		references = append(references, secret.Reference)
+		if _, ok := seenFields[secret.Reference]; ok {
+			continue
+		}
+		seenFields[secret.Reference] = struct{}{}
+		fields = append(fields, secret.Reference)
 	}
-	return references
+	return fields, files
+}
+
+func wrapResolutionError(err error) error {
+	suggestions := []string{
+		"Check the failed 1Password references listed above",
+		"Create any missing vaults, items, fields, or files before restarting opnix-secrets.service",
+		"If rate-limited, wait for the 1Password reset window before retrying",
+	}
+	var resolutionErr *errors.ProviderResolutionError
+	if stderrors.As(err, &resolutionErr) {
+		for _, failure := range resolutionErr.Failures {
+			if failure.Kind == errors.ProviderErrorMissingReference {
+				suggestions = append(suggestions,
+					"If this service belongs to an older NixOS generation, restore any retired 1Password references until its rollback window closes",
+				)
+				break
+			}
+		}
+	}
+	return errors.WrapWithSuggestions(
+		err,
+		"Resolving 1Password references",
+		"secret processing",
+		suggestions,
+	)
 }
 
 // setOwnership sets the file ownership based on owner and group names

--- a/internal/secrets/processor_test.go
+++ b/internal/secrets/processor_test.go
@@ -15,8 +15,27 @@ import (
 // Mock client for testing
 type mockClient struct {
 	secrets      map[string]string
+	files        map[string][]byte
 	resolveCalls map[string]int
 	resolveErr   error
+	fileErr      error
+	fileCalls    int
+}
+
+func (m *mockClient) ResolveFiles(references []string) (map[string][]byte, error) {
+	m.fileCalls++
+	if m.fileErr != nil {
+		return nil, m.fileErr
+	}
+	resolved := make(map[string][]byte, len(references))
+	for _, reference := range references {
+		value, ok := m.files[reference]
+		if !ok {
+			return nil, fmt.Errorf("file not found")
+		}
+		resolved[reference] = value
+	}
+	return resolved, nil
 }
 
 func (m *mockClient) ResolveSecret(reference string) (string, error) {
@@ -142,6 +161,91 @@ func TestProcessor(t *testing.T) {
 	}
 }
 
+func TestProcessorWritesBinaryFileExactly(t *testing.T) {
+	const reference = "op://vault/document/private-key"
+	want := []byte{0x00, 0xff, 0xfe, '\n', 0x80, 0x01}
+	tmpDir := t.TempDir()
+	processor := NewProcessor(&mockClient{files: map[string][]byte{reference: want}}, tmpDir)
+
+	_, err := processor.Process(&config.Config{Secrets: []config.Secret{{
+		Path:      "keys/private.key",
+		Reference: reference,
+		Kind:      config.SecretKindFile,
+	}}})
+	if err != nil {
+		t.Fatalf("Failed to process binary file: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmpDir, "keys/private.key"))
+	if err != nil {
+		t.Fatalf("Failed to read binary output: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Binary output changed: got %v, want %v", got, want)
+	}
+}
+
+func TestProcessorResolvesAllKindsBeforeWrites(t *testing.T) {
+	const (
+		fieldReference = "op://vault/item/password"
+		fileReference  = "op://vault/item/private-key"
+	)
+	tmpDir := t.TempDir()
+	existingPath := filepath.Join(tmpDir, "password")
+	if err := os.WriteFile(existingPath, []byte("existing-password"), 0600); err != nil {
+		t.Fatalf("Failed to create existing secret: %v", err)
+	}
+	fileErr := &errors.ProviderResolutionError{Failures: []*errors.ProviderError{{
+		Kind:      errors.ProviderErrorMissingReference,
+		Reference: fileReference,
+		Issue:     "file not found",
+	}}}
+	processor := NewProcessor(&mockClient{
+		secrets:      map[string]string{fieldReference: "new-password"},
+		fileErr:      fileErr,
+		resolveCalls: map[string]int{},
+	}, tmpDir)
+
+	result, err := processor.Process(&config.Config{Secrets: []config.Secret{
+		{Path: "password", Reference: fieldReference},
+		{Path: "private-key", Reference: fileReference, Kind: config.SecretKindFile},
+	}})
+	if err == nil {
+		t.Fatal("Expected file resolution error")
+	}
+	if result != nil {
+		t.Fatalf("Expected no result, got %#v", result)
+	}
+	if got := errors.ExitCode(err); got != errors.ExitCodeMissingReference {
+		t.Fatalf("Expected exit code %d, got %d", errors.ExitCodeMissingReference, got)
+	}
+	content, readErr := os.ReadFile(existingPath)
+	if readErr != nil {
+		t.Fatalf("Failed to read existing secret: %v", readErr)
+	}
+	if string(content) != "existing-password" {
+		t.Fatalf("Field was updated before file resolution completed: %q", content)
+	}
+}
+
+func TestProcessorResolutionFailureDoesNotCreateOutputDirectory(t *testing.T) {
+	const reference = "op://vault/item/missing.bin"
+	outputDir := filepath.Join(t.TempDir(), "secrets")
+	processor := NewProcessor(&mockClient{fileErr: &errors.ProviderResolutionError{Failures: []*errors.ProviderError{{
+		Kind: errors.ProviderErrorMissingReference, Reference: reference, Issue: "file not found",
+	}}}}, outputDir)
+
+	_, err := processor.Process(&config.Config{Secrets: []config.Secret{{
+		Path: "missing.bin", Reference: reference, Kind: config.SecretKindFile,
+	}}})
+	if err == nil {
+		t.Fatal("Expected resolution failure")
+	}
+	if _, statErr := os.Stat(outputDir); !os.IsNotExist(statErr) {
+		t.Fatalf("Expected output directory to remain absent, got %v", statErr)
+	}
+}
+
 func TestProcessorResolvesDuplicateReferencesOnce(t *testing.T) {
 	mock := &mockClient{
 		secrets: map[string]string{
@@ -173,6 +277,37 @@ func TestProcessorResolvesDuplicateReferencesOnce(t *testing.T) {
 
 	if got := mock.resolveCalls["op://vault/shared/field"]; got != 1 {
 		t.Fatalf("Expected duplicate reference to be resolved once, got %d", got)
+	}
+}
+
+func TestProcessorResolvesDuplicateFileReferenceOnce(t *testing.T) {
+	const reference = "op://vault/item/archive.bin"
+	want := []byte{0x00, 0xff, 0x01}
+	mock := &mockClient{files: map[string][]byte{reference: want}}
+	tmpDir := t.TempDir()
+	processor := NewProcessor(mock, tmpDir)
+
+	result, err := processor.Process(&config.Config{Secrets: []config.Secret{
+		{Path: "first.bin", Reference: reference, Kind: config.SecretKindFile},
+		{Path: "second.bin", Reference: reference, Kind: config.SecretKindFile},
+	}})
+	if err != nil {
+		t.Fatalf("Failed to process duplicate file reference: %v", err)
+	}
+	if result.ProcessedCount != 2 {
+		t.Fatalf("Expected 2 processed files, got %d", result.ProcessedCount)
+	}
+	if mock.fileCalls != 1 {
+		t.Fatalf("Expected one batched file resolution, got %d", mock.fileCalls)
+	}
+	for _, name := range []string{"first.bin", "second.bin"} {
+		got, readErr := os.ReadFile(filepath.Join(tmpDir, name))
+		if readErr != nil {
+			t.Fatalf("Failed to read %s: %v", name, readErr)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("File %s changed bytes: got %v, want %v", name, got, want)
+		}
 	}
 }
 

--- a/internal/systemd/integration_test.go
+++ b/internal/systemd/integration_test.go
@@ -154,6 +154,35 @@ func TestHashStoreChangeDetection(t *testing.T) {
 	}
 }
 
+func TestHashStoreDetectsBinaryChanges(t *testing.T) {
+	tempDir := t.TempDir()
+	secretPath := filepath.Join(tempDir, "binary-secret")
+	store, err := NewHashStore(filepath.Join(tempDir, "hashes.json"))
+	if err != nil {
+		t.Fatalf("Failed to create hash store: %v", err)
+	}
+
+	first := []byte{0x00, 0xff, 0xfe, 0x80, 0x01}
+	if err := os.WriteFile(secretPath, first, 0600); err != nil {
+		t.Fatalf("Failed to write binary secret: %v", err)
+	}
+	if changed, err := store.hasChanged(secretPath); err != nil || !changed {
+		t.Fatalf("Expected initial binary content to be detected, changed=%v err=%v", changed, err)
+	}
+	if changed, err := store.hasChanged(secretPath); err != nil || changed {
+		t.Fatalf("Expected identical binary content to be unchanged, changed=%v err=%v", changed, err)
+	}
+
+	second := append([]byte(nil), first...)
+	second[2] = 0xfd
+	if err := os.WriteFile(secretPath, second, 0600); err != nil {
+		t.Fatalf("Failed to update binary secret: %v", err)
+	}
+	if changed, err := store.hasChanged(secretPath); err != nil || !changed {
+		t.Fatalf("Expected binary byte change to be detected, changed=%v err=%v", changed, err)
+	}
+}
+
 func TestExtractServiceActions(t *testing.T) {
 	cfg := mockSystemdIntegration()
 	manager := &Manager{config: cfg}

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/user"
 	"regexp"
@@ -23,6 +24,7 @@ func NewValidator() *Validator {
 type SecretData struct {
 	Path         string
 	Reference    string
+	Kind         string
 	Owner        string
 	Group        string
 	Mode         string
@@ -58,9 +60,18 @@ func (v *Validator) ValidateConfigStruct(secrets []SecretData) error {
 
 // validateSecret validates individual secret configuration
 func (v *Validator) validateSecret(secret SecretData, secretName string, seenPaths map[string]string) error {
+	if err := v.validateKind(secret.Kind, secretName); err != nil {
+		return err
+	}
+
 	// Validate reference
 	if err := v.validateReference(secret.Reference, secretName); err != nil {
 		return err
+	}
+	if secret.Kind == "file" {
+		if err := v.validateFileReference(secret.Reference, secretName); err != nil {
+			return err
+		}
 	}
 
 	// Validate path and resolve final path
@@ -88,6 +99,42 @@ func (v *Validator) validateSecret(secret SecretData, secretName string, seenPat
 		return err
 	}
 
+	return nil
+}
+
+func (v *Validator) validateKind(kind, secretName string) error {
+	if kind == "" || kind == "field" || kind == "file" {
+		return nil
+	}
+	return errors.ConfigValidationError(
+		fmt.Sprintf("%s.kind", secretName),
+		kind,
+		"Kind must be field or file",
+		[]string{"Use field for text values", "Use file for Documents and attachments"},
+	)
+}
+
+func (v *Validator) validateFileReference(reference, secretName string) error {
+	parts := strings.Split(strings.TrimPrefix(reference, "op://"), "/")
+	if len(parts) != 3 {
+		return errors.ConfigValidationError(
+			fmt.Sprintf("%s.reference", secretName),
+			reference,
+			"File references must have exactly 3 parts: vault/item/filename",
+			[]string{"Use format: op://Vault/Item/filename", "Remove section or field selectors from file references"},
+		)
+	}
+	for _, part := range parts {
+		decoded, err := url.PathUnescape(part)
+		if err != nil || decoded == "" {
+			return errors.ConfigValidationError(
+				fmt.Sprintf("%s.reference", secretName),
+				reference,
+				"File reference contains an invalid or empty component",
+				[]string{"Percent-encode special characters in vault, item, and filename components"},
+			)
+		}
+	}
 	return nil
 }
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -76,6 +76,121 @@
       touch $out
     '';
 }
+// (let
+  lib = pkgs.lib;
+  hmLib = lib.extend (_: _: {
+    hm.dag = {
+      entryBefore = _: value: value;
+      entryAfter = _: value: value;
+    };
+  });
+  hmConfig =
+    (hmLib.evalModules {
+      specialArgs = {inherit pkgs;};
+      modules = [
+        ./hm-module.nix
+        {
+          options = {
+            home.homeDirectory = lib.mkOption {type = lib.types.str;};
+            home.username = lib.mkOption {type = lib.types.str;};
+            home.packages = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              default = [];
+            };
+            home.activation = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = {};
+            };
+            assertions = lib.mkOption {
+              type = lib.types.listOf lib.types.anything;
+              default = [];
+            };
+          };
+          config = {
+            home.homeDirectory = "/home/opnix-test";
+            home.username = "opnix-test";
+            programs.onepassword-secrets = {
+              enable = true;
+              secrets = {
+                defaultSecret.reference = "op://Example/Service/password";
+                fileSecret = {
+                  reference = "op://Example/Document/archive.bin";
+                  kind = "file";
+                };
+              };
+            };
+          };
+        }
+      ];
+    }).config;
+  darwinConfig =
+    (lib.evalModules {
+      specialArgs = {inherit pkgs;};
+      modules = [
+        ./darwin-module.nix
+        {
+          options = {
+            assertions = lib.mkOption {
+              type = lib.types.listOf lib.types.anything;
+              default = [];
+            };
+            users.knownGroups = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [];
+            };
+            users.groups = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = {};
+            };
+            users.users = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = {};
+            };
+            launchd.daemons = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = {};
+            };
+            system.activationScripts.extraActivation.text = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+            };
+          };
+          config.services.onepassword-secrets = {
+            enable = true;
+            secrets = {
+              defaultSecret.reference = "op://Example/Service/password";
+              fileSecret = {
+                reference = "op://Example/Document/archive.bin";
+                kind = "file";
+              };
+            };
+          };
+        }
+      ];
+    }).config;
+in {
+  hm-module-evaluation = assert hmConfig.programs.onepassword-secrets.secrets.defaultSecret.kind == "field";
+  assert hmConfig.programs.onepassword-secrets.secrets.fileSecret.kind == "file";
+    pkgs.runCommand "opnix-hm-module-evaluation" {
+      moduleScript = hmConfig.home.activation.retrieveOpnixSecrets;
+    } ''
+      config_file=$(printf '%s\n' "$moduleScript" | grep -o '/nix/store/[^ ]*-hm-opnix-declarative-secrets.json' | head -n1)
+      grep -Fq '"kind":"field"' "$config_file"
+      grep -Fq '"kind":"file"' "$config_file"
+      touch $out
+    '';
+
+  darwin-module-evaluation = assert darwinConfig.services.onepassword-secrets.secrets.defaultSecret.kind == "field";
+  assert darwinConfig.services.onepassword-secrets.secrets.fileSecret.kind == "file";
+    pkgs.runCommand "opnix-darwin-module-evaluation" {
+      moduleScript = builtins.elemAt darwinConfig.launchd.daemons.opnix-secrets.serviceConfig.ProgramArguments 2;
+    } ''
+      config_file=$(printf '%s\n' "$moduleScript" | grep -o '/nix/store/[^ ]*-opnix-declarative-secrets.json' | head -n1)
+      grep -Fq '"kind":"field"' "$config_file"
+      grep -Fq '"kind":"file"' "$config_file"
+      touch $out
+    '';
+})
 // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux (let
   nixosConfig = polling:
     (nixpkgs.lib.nixosSystem {
@@ -87,6 +202,10 @@
           services.onepassword-secrets = {
             enable = true;
             secrets.testSecret.reference = "op://Example/Service/password";
+            secrets.testFile = {
+              reference = "op://Example/Document/archive.bin";
+              kind = "file";
+            };
             systemdIntegration.polling = polling;
           };
         }
@@ -101,6 +220,8 @@
 in {
   module-evaluation = assert !(defaultPollingConfig.systemd.services ? opnix-secrets-poll);
   assert !(defaultPollingConfig.systemd.timers ? opnix-secrets-poll);
+  assert defaultPollingConfig.services.onepassword-secrets.secrets.testSecret.kind == "field";
+  assert defaultPollingConfig.services.onepassword-secrets.secrets.testFile.kind == "file";
   assert enabledPollingConfig.systemd.services.opnix-secrets-poll.serviceConfig.Type == "oneshot";
   assert !(enabledPollingConfig.systemd.services.opnix-secrets-poll.serviceConfig ? RemainAfterExit);
   assert nixpkgs.lib.hasInfix "systemctl stop opnix-secrets-watcher.path" enabledPollingConfig.systemd.services.opnix-secrets-poll.script;
@@ -108,7 +229,12 @@ in {
   assert enabledPollingConfig.systemd.timers.opnix-secrets-poll.timerConfig.OnActiveSec == "45min";
   assert enabledPollingConfig.systemd.timers.opnix-secrets-poll.timerConfig.OnUnitActiveSec == "45min";
   assert enabledPollingConfig.systemd.timers.opnix-secrets-poll.timerConfig.Unit == "opnix-secrets-poll.service";
-    pkgs.runCommand "opnix-module-evaluation" {} ''
+    pkgs.runCommand "opnix-module-evaluation" {
+      moduleScript = defaultPollingConfig.systemd.services.opnix-secrets.script;
+    } ''
+      config_file=$(printf '%s\n' "$moduleScript" | grep -o '/nix/store/[^ ]*-opnix-declarative-secrets.json' | head -n1)
+      grep -Fq '"kind":"field"' "$config_file"
+      grep -Fq '"kind":"file"' "$config_file"
       touch $out
     '';
 })

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -88,8 +88,14 @@ in {
         options = {
           reference = lib.mkOption {
             type = lib.types.str;
-            description = "1Password reference in the format op://Vault/Item/field";
+            description = "1Password reference in the format op://Vault/Item/field or op://Vault/Item/filename";
             example = "op://Homelab/Database/password";
+          };
+
+          kind = lib.mkOption {
+            type = lib.types.enum ["field" "file"];
+            default = "field";
+            description = "Whether to resolve a text field or download a Document/attachment as raw bytes";
           };
 
           path = lib.mkOption {
@@ -212,6 +218,7 @@ in {
                   then secret.path
                   else name;
                 reference = secret.reference;
+                kind = secret.kind;
                 owner = secret.owner;
                 group = secret.group;
                 mode = secret.mode;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -57,8 +57,14 @@
 
       reference = lib.mkOption {
         type = lib.types.str;
-        description = "1Password reference in the format op://vault/item/field";
+        description = "1Password reference in the format op://vault/item/field or op://vault/item/filename";
         example = "op://Personal/ssh-key/private-key";
+      };
+
+      kind = lib.mkOption {
+        type = lib.types.enum ["field" "file"];
+        default = "field";
+        description = "Whether to resolve a text field or download a Document/attachment as raw bytes";
       };
 
       owner = lib.mkOption {
@@ -121,6 +127,7 @@ in {
       example = {
         sshPrivateKey = {
           reference = "op://Personal/SSH/private-key";
+          kind = "file";
           path = ".ssh/id_rsa";
           mode = "0600";
         };
@@ -180,6 +187,7 @@ in {
                   then secret.path
                   else name;
                 reference = secret.reference;
+                kind = secret.kind;
                 owner = secret.owner;
                 group = secret.group;
                 mode = secret.mode;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -77,8 +77,14 @@ in {
         options = {
           reference = lib.mkOption {
             type = lib.types.str;
-            description = "1Password reference in the format op://Vault/Item/field";
+            description = "1Password reference in the format op://Vault/Item/field or op://Vault/Item/filename";
             example = "op://Homelab/Database/password";
+          };
+
+          kind = lib.mkOption {
+            type = lib.types.enum ["field" "file"];
+            default = "field";
+            description = "Whether to resolve a text field or download a Document/attachment as raw bytes";
           };
 
           path = lib.mkOption {
@@ -361,6 +367,7 @@ in {
                   then secret.path
                   else name;
                 reference = secret.reference;
+                kind = secret.kind;
                 owner = secret.owner;
                 group = secret.group;
                 mode = secret.mode;


### PR DESCRIPTION
# Personal Notes

<!-- Intentionally left blank for a human to fill in after the PR is opened. -->

# AI Notes
## Linear
- Issue: https://linear.app/brizzbuzz/issue/MMI-928/support-binary-1password-files

## Summary
- Add explicit `kind = "file"` support for byte-exact 1Password Document items and attachments while preserving the existing batched text-field path.
- Resolve exact vault/item title-or-ID selectors and exact filenames through the pinned SDK Items/Files API before materializing any configured secret.
- Expose matching JSON, NixOS, Home Manager, and nix-darwin configuration with generated-JSON evaluation checks and binary-focused regression tests.
- Closes #25.
- Source paths: `internal/onepass/client.go`, `internal/secrets/processor.go`, `internal/config/config.go`, `nix/{module,hm-module,darwin-module,checks}.nix`, and user documentation.

## Scope Check
- Matches issue because: binary Documents and attachments now remain raw `[]byte` values through retrieval, materialization, and content hashing, including NUL and invalid UTF-8.
- Changed file groups: provider adapter and tests implement file lookup/download; processor/config/validation preserve the all-resolution-before-write boundary; modules serialize the public kind; docs specify selectors and limits.
- Out of scope / deferred: automatic fallback, `op` CLI integration, uploads/replacements, files over the SDK 50 MB limit, atomic-write/symlink redesign, alternate selectors, and dependency upgrades.

## Validation
- `nix develop -c go test ./... -count=1` passed.
- `nix develop -c go vet ./...` passed.
- `nix flake check` passed, including Go tests, lint, Nix formatting, NixOS/Home Manager/nix-darwin evaluation, and generated JSON checks.
- `nix flake check --no-build --all-systems` passed for all four default systems.
- `git diff --check` passed.
- Two independent pre-PR reviews found and resolved the output-directory timing and module-parity coverage gaps; final review found no remaining findings.
- Residual risk: SDK behavior is exercised through exact mock interfaces rather than a live 1Password service account.

## Follow-ups
- None.